### PR TITLE
feat : develop TodoReminder's Edit feature

### DIFF
--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -6,22 +6,24 @@ import { IoMdCalendar } from 'react-icons/io';
 import { ko } from 'date-fns/locale';
 import { Button } from '..';
 import { customPropReceiver } from '../../constants';
-import { format, today } from '../../utils/date';
+import { format } from '../../utils/date';
 import { useClickOutside } from '../../hooks';
 
 interface DatePickerProps {
 	selected: Date | undefined;
 	setSelected: (date: Date) => void | Dispatch<SetStateAction<Date | undefined>>;
 	error?: FieldError;
+	disabled?: { after: Date };
+	isFloated?: boolean;
 }
 
-const DatePicker = ({ selected, setSelected, error, ...props }: DatePickerProps) => {
+const DatePicker = ({ selected, setSelected, error, disabled, isFloated = false, ...props }: DatePickerProps) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	const targetRef = useClickOutside<HTMLDivElement>({ eventHandler: () => setIsOpen(false) });
 
 	return (
-		<Container ref={targetRef}>
+		<Container ref={targetRef} isFloated={isFloated}>
 			<TriggerButton type="button" $isDaySelected={selected ? true : false} onClick={() => setIsOpen(!isOpen)} $isOpen={isOpen}>
 				<IconBackground>
 					<IoMdCalendar size="24" color="var(--grey800)" />
@@ -29,43 +31,45 @@ const DatePicker = ({ selected, setSelected, error, ...props }: DatePickerProps)
 				<span>{selected ? format(selected) : 'Select Date'}</span>
 			</TriggerButton>
 			{error && <ErrorMessage>﹡ {error?.message}</ErrorMessage>}
-			{isOpen && (
-				<DayPicker
-					mode="single"
-					locale={ko}
-					required={true}
-					selected={selected}
-					disabled={{ after: today }}
-					onSelect={setSelected}
-					captionLayout="dropdown"
-					timeZone="Asia/Seoul"
-					showOutsideDays
-					onDayClick={() => {
-						setIsOpen(false);
-					}}
-					{...props}
-				/>
-			)}
+			<DayPickerWrapper isFloated={isFloated}>
+				{isOpen && (
+					<DayPicker
+						mode="single"
+						locale={ko}
+						required={true}
+						selected={selected}
+						disabled={disabled}
+						onSelect={setSelected}
+						captionLayout="dropdown"
+						timeZone="Asia/Seoul"
+						showOutsideDays
+						onDayClick={() => {
+							setIsOpen(false);
+						}}
+						{...props}
+					/>
+				)}
+			</DayPickerWrapper>
 		</Container>
 	);
 };
 
-const Container = styled.div`
-	position: relative;
+const Container = styled.div<{ isFloated: boolean }>`
+	position: ${({ isFloated }) => (isFloated ? 'relative' : 'static')};
 	display: inline-flex;
 	flex-direction: column;
 	gap: 4px;
-	margin-top: 8px;
 `;
 
 const TriggerButton = styled(Button, customPropReceiver)<{ $isDaySelected: boolean; $isOpen: boolean }>`
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	padding: calc(var(--padding-container-mobile) * 0.5) var(--padding-container-mobile);
+	padding: calc(var(--padding-container-mobile) * 0.75) var(--padding-container-mobile);
+
 	color: ${({ $isDaySelected }) => ($isDaySelected ? 'var(--grey900)' : 'var(--grey500)')};
 	background-color: ${({ $isOpen }) => ($isOpen ? 'var(--white)' : 'var(--greyOpacity50)')};
-	border: 1px solid var(--grey100);
+	border: ${({ $isOpen }) => `1px solid ${$isOpen ? 'var(--grey300)' : 'var(--grey100)'}`};
 	border-radius: var(--radius-m);
 	font-size: var(--fz-p);
 	font-weight: var(--fw-semibold);
@@ -85,6 +89,11 @@ const ErrorMessage = styled.p`
 	padding-left: 4px;
 	font-size: var(--fz-sm);
 	color: var(--red200);
+`;
+
+const DayPickerWrapper = styled.div<{ isFloated: boolean }>`
+	position: ${({ isFloated }) => (isFloated ? 'absolute' : 'static')};
+	top: ${({ isFloated }) => (isFloated ? '64px' : '0')};
 `;
 
 export default DatePicker;

--- a/src/components/common/TagsInput.tsx
+++ b/src/components/common/TagsInput.tsx
@@ -10,11 +10,12 @@ export interface Tag {
 }
 
 interface TagsInputProps {
+	inputId: string;
 	tags: Tag[];
 	onChange: (tags: Tag[]) => void;
 }
 
-const TagsInput = ({ tags, onChange }: TagsInputProps) => {
+const TagsInput = ({ inputId, tags, onChange }: TagsInputProps) => {
 	const [value, setValue] = useState<string>('');
 	const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -48,6 +49,7 @@ const TagsInput = ({ tags, onChange }: TagsInputProps) => {
 			))}
 			<Input
 				type="text"
+				id={inputId}
 				value={value}
 				onChange={e => setValue(e.target.value)}
 				onKeyDown={e => {
@@ -115,6 +117,7 @@ const Input = styled.input`
 	flex-shrink: 0;
 	width: 100%;
 	font-size: var(--fz-p);
+	cursor: pointer;
 `;
 
 export default TagsInput;

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -77,6 +77,7 @@ const Container = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
+	width: 100%;
 `;
 
 const Label = styled.label`

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -34,11 +34,12 @@ interface TextFieldProps extends Omit<HTMLAttributes<HTMLInputElement>, 'size'> 
 	onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
 	maxLength?: number;
 	disabled?: boolean;
+	variant?: 'sm' | 'md' | 'lg';
 }
 
 TextInput.TextField = forwardRef(
-	({ type = 'text', id, name, placeholder, ...props }: TextFieldProps, ref: ForwardedRef<HTMLInputElement>) => {
-		return <Input type={type} id={id} name={name} placeholder={placeholder} ref={ref} {...props} />;
+	({ type = 'text', id, name, placeholder, variant = 'lg', ...props }: TextFieldProps, ref: ForwardedRef<HTMLInputElement>) => {
+		return <Input type={type} id={id} name={name} placeholder={placeholder} ref={ref} variant={variant} {...props} />;
 	},
 );
 
@@ -52,6 +53,7 @@ TextInput.ControlledTextField = ({
 	onBlur,
 	maxLength,
 	disabled,
+	variant = 'lg',
 	...props
 }: TextFieldProps) => {
 	return (
@@ -65,6 +67,7 @@ TextInput.ControlledTextField = ({
 			onBlur={onBlur}
 			maxLength={maxLength ? maxLength : undefined}
 			disabled={disabled}
+			variant={variant}
 			{...props}
 		/>
 	);
@@ -87,10 +90,15 @@ const Message = styled.p`
 	color: var(--red200);
 `;
 
-const Input = styled.input<{ name: string }>`
-	padding: var(--padding-container-mobile);
+const Input = styled.input<{ name: string; variant: 'sm' | 'md' | 'lg' }>`
+	padding: ${({ variant }) =>
+		variant === 'lg'
+			? 'var(--padding-container-mobile)'
+			: variant === 'md'
+			? 'calc(var(--padding-container-mobile) * 0.75) calc(var(--padding-container-mobile) * 0.75)'
+			: 'calc(var(--padding-container-mobile) * 0.5)'};
 	width: 100%;
-	font-size: var(--fz-h5);
+	font-size: ${({ variant }) => (variant === 'lg' ? 'var(--fz-h5)' : variant === 'md' ? 'var(--fz-h7)' : 'var(--fz-p)')};
 	font-weight: ${({ name }) => (name === 'title' ? 'var(--fw-semibold)' : 'var(--fw-regular)')};
 	color: var(--black);
 	border-bottom: 1px solid var(--greyOpacity100);

--- a/src/components/modal/diary/EditDiaryContentModal.tsx
+++ b/src/components/modal/diary/EditDiaryContentModal.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import styled from '@emotion/styled';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -27,12 +26,16 @@ const EditDiaryContentModal = ({ id, type, data, onClose }: EditDiaryContentModa
 	const {
 		register,
 		control,
-		setValue,
 		formState: { errors },
 		handleSubmit,
 	} = useForm<EditContentFormSchema>({
 		resolver: zodResolver(editContentFormSchema),
-		defaultValues: { tags: [] },
+		defaultValues: {
+			title: data?.title,
+			content: data?.content,
+			feeling: data?.feeling,
+			tags: data?.tags!.map((tag, idx) => ({ id: idx, tag })),
+		},
 	});
 
 	const navigate = useNavigate();
@@ -78,17 +81,6 @@ const EditDiaryContentModal = ({ id, type, data, onClose }: EditDiaryContentModa
 		}
 	};
 
-	useEffect(() => {
-		setValue('title', data?.title);
-		setValue('content', data?.content);
-		setValue('feeling', data?.feeling);
-		setValue(
-			'tags',
-			data?.tags!.map((tag, idx) => ({ id: idx, tag })),
-		);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [setValue]);
-
 	return (
 		<ModalLayout id={id} type={type} title={<BiMessageSquareEdit size="32" color="var(--black)" />} onClose={onClose}>
 			<Group onSubmit={handleSubmit(onSubmit)}>
@@ -118,7 +110,7 @@ const EditDiaryContentModal = ({ id, type, data, onClose }: EditDiaryContentModa
 				<Controller
 					name="tags"
 					control={control}
-					render={({ field: { value, onChange } }) => <TagsInput tags={value} onChange={onChange} />}
+					render={({ field: { name, value, onChange } }) => <TagsInput inputId={name} tags={value} onChange={onChange} />}
 				/>
 				<UpdateButton type="submit">{isLoading ? Loading : 'Upload'}</UpdateButton>
 			</Group>

--- a/src/components/modal/expenseTracker/AddPaymentModal.tsx
+++ b/src/components/modal/expenseTracker/AddPaymentModal.tsx
@@ -70,6 +70,7 @@ const AddPaymentModal = ({ id, type, onClose }: AddPaymentModalProps) => {
 						selected={watch('usage_date')}
 						setSelected={(date: Date) => setValue('usage_date', date, { shouldValidate: true })}
 						error={errors['usage_date']}
+						disabled={{ after: today }}
 					/>
 
 					<TextInput errorMessage={errors['place']?.message}>

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -2,6 +2,7 @@ export * from './filmRecipe';
 export * from './diary';
 export * from './expenseTracker';
 export * from './user';
+export * from './todoReminder';
 
 export { default as ModalContainer } from './ModalContainer';
 export { default as ModalLayout } from './ModalLayout';

--- a/src/components/modal/modalType.ts
+++ b/src/components/modal/modalType.ts
@@ -1,11 +1,16 @@
 import { ElementType } from 'react';
-import { AddPaymentModal } from './expenseTracker';
-import { AddFilmRecipeModal, FilmRecipeModal, RemoveFilmRecipeConfirmModal } from './filmRecipe';
-import { EditDiaryContentModal } from './diary';
-import { ResetPasswordForEmailModal } from './user';
-import UpdateProfileModal from './user/UpdateProfileModal';
+import {
+	AddPaymentModal,
+	AddFilmRecipeModal,
+	FilmRecipeModal,
+	RemoveFilmRecipeConfirmModal,
+	EditDiaryContentModal,
+	ResetPasswordForEmailModal,
+	UpdateProfileModal,
+	TodoItemEditModal,
+} from '.';
 
-type ModalDataType = 'diary' | 'filmRecipe' | 'financialLedger' | 'user';
+type ModalDataType = 'diary' | 'filmRecipe' | 'financialLedger' | 'user' | 'todoReminder';
 
 type ModalConfigItem = {
 	type: ModalDataType;
@@ -28,6 +33,9 @@ type ModalConfig = {
 		RESET_PASSWORD: ModalConfigItem;
 		PROFILE: ModalConfigItem;
 	};
+	TODO_REMINDER: {
+		EDIT: ModalConfigItem;
+	};
 };
 
 const modalType = {
@@ -35,6 +43,7 @@ const modalType = {
 	FILM_RECIPE: 'filmRecipe',
 	DIARY: 'diary',
 	USER: 'user',
+	TODO_REMINDER: 'todoReminder',
 } as const;
 
 const MODAL_CONFIG: ModalConfig = {
@@ -72,6 +81,12 @@ const MODAL_CONFIG: ModalConfig = {
 		PROFILE: {
 			type: modalType.USER,
 			Component: UpdateProfileModal,
+		},
+	},
+	TODO_REMINDER: {
+		EDIT: {
+			type: modalType.TODO_REMINDER,
+			Component: TodoItemEditModal,
 		},
 	},
 };

--- a/src/components/modal/todoReminder/TodoItemEditModal.tsx
+++ b/src/components/modal/todoReminder/TodoItemEditModal.tsx
@@ -1,0 +1,98 @@
+import styled from '@emotion/styled';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, DatePicker, TagsInput, TextInput } from '../../common';
+import { ModalLayout } from '..';
+import type { Todo } from '../../../supabase/schema';
+import { ModalDataType } from '../modalType';
+import { editTodoItemFormSchema, EditTodoItemFormSchema } from './schema';
+
+interface TodoItemEditModal {
+	id: string;
+	type: ModalDataType;
+	onClose: () => void;
+	data: Todo;
+}
+
+const TodoItemEditModal = ({ id, type, onClose, data }: TodoItemEditModal) => {
+	const {
+		register,
+		control,
+		watch,
+		setValue,
+		formState: { errors },
+		handleSubmit,
+	} = useForm<EditTodoItemFormSchema>({
+		resolver: zodResolver(editTodoItemFormSchema),
+		defaultValues: { content: data?.content, tags: data?.tags!.map((tag, idx) => ({ id: idx, tag })), reminderTime: data?.reminder_time },
+	});
+
+	const onSubmit = () => {};
+
+	return (
+		<ModalLayout id={id} type={type} title={'Detail'} onClose={onClose}>
+			<Form onSubmit={handleSubmit(onSubmit)}>
+				<TextInput errorMessage={errors?.content?.message}>
+					<TextInput.TextField id="todoItem_editModal_content" {...register('content')} placeholder="Change content" variant="lg" />
+				</TextInput>
+				<Controller
+					name="tags"
+					control={control}
+					render={({ field: { name, value, onChange } }) => <TagsInput inputId={name} tags={value} onChange={onChange} />}
+				/>
+				<DatePicker
+					selected={watch('reminderTime')}
+					setSelected={(date: Date) => setValue('reminderTime', date, { shouldValidate: true })}
+					error={errors['reminderTime']}
+				/>
+				<ButtonGroup>
+					<DeleteButton type="button">Delete</DeleteButton>
+					<SubmitButton type="submit">Edit</SubmitButton>
+				</ButtonGroup>
+			</Form>
+		</ModalLayout>
+	);
+};
+
+const Form = styled.form`
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+`;
+
+const ButtonGroup = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+	margin-top: 32px;
+`;
+
+const DeleteButton = styled(Button)`
+	padding: var(--padding-container-mobile);
+	width: 100%;
+	color: var(--white);
+	background-color: var(--grey300);
+	font-size: var(--fz-p);
+	font-weight: var(--fw-semibold);
+
+	&:hover {
+		background-color: var(--grey200);
+	}
+`;
+
+const SubmitButton = styled(Button)`
+	/* margin-top: auto; */
+	padding: var(--padding-container-mobile);
+	width: 100%;
+	color: var(--white);
+	background-color: var(--black);
+	font-size: var(--fz-p);
+	font-weight: var(--fw-semibold);
+
+	&:hover {
+		background-color: var(--grey900);
+	}
+`;
+
+export default TodoItemEditModal;

--- a/src/components/modal/todoReminder/index.ts
+++ b/src/components/modal/todoReminder/index.ts
@@ -1,0 +1,1 @@
+export { default as TodoItemEditModal } from './TodoItemEditModal';

--- a/src/components/modal/todoReminder/schema.ts
+++ b/src/components/modal/todoReminder/schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+type EditTodoItemFormSchema = z.infer<typeof editTodoItemFormSchema>;
+
+const editTodoItemFormSchema = z.object({
+	content: z.string({ required_error: 'Necessarily in need' }).min(1, { message: 'Write Content' }),
+	tags: z.array(z.object({ id: z.number(), tag: z.string() })).default([]),
+	reminderTime: z.date({ invalid_type_error: 'Select the correct Data' }),
+});
+
+export type { EditTodoItemFormSchema };
+export { editTodoItemFormSchema };

--- a/src/components/modal/user/index.ts
+++ b/src/components/modal/user/index.ts
@@ -1,1 +1,2 @@
 export { default as ResetPasswordForEmailModal } from './ResetPasswordForEmailModal';
+export { default as UpdateProfileModal } from './UpdateProfileModal';

--- a/src/components/todoReminder/TodoItem.tsx
+++ b/src/components/todoReminder/TodoItem.tsx
@@ -5,7 +5,7 @@ import { RiCloseFill } from 'react-icons/ri';
 import { RiInformation2Line } from 'react-icons/ri';
 import type { Todo } from '../../supabase/schema';
 import { Button, Checkbox, TextInput } from '../common';
-import { useDragAndDrop, useLoading } from '../../hooks';
+import { useDrag, useLoading } from '../../hooks';
 import useToastStore from '../../store/useToastStore';
 import { removeTodo, updatedTodoCompleted } from '../../supabase/todos';
 import queryKey from '../../constants/queryKey';
@@ -29,7 +29,7 @@ const TodoItem = ({ todo, order }: TodoProps) => {
 		dragX,
 		dragContainerRef,
 		handlers: { handleTouchStart, handleTouchMove, handleTouchEnd },
-	} = useDragAndDrop();
+	} = useDrag();
 
 	// TextInput 바깥 클릭 시 TextInput에서 Label로 다시 바뀌도록 변경
 	// TODO: web-socket 연결로 reminder 만들기

--- a/src/components/todoReminder/schema.ts
+++ b/src/components/todoReminder/schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+type TodoItemSchema = z.infer<typeof todoItemSchema>;
+
+const todoItemSchema = z.object({
+	content: z.string({ required_error: 'Necessarily in need' }).min(1, { message: 'Write Content' }),
+});
+
+export type { TodoItemSchema };
+export { todoItemSchema };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,4 @@ export { default as useOverlayFixed } from './useOverlayFixed';
 export { default as useFilmRecipeImage } from './useFilmRecipeImage';
 export { default as useClickOutside } from './useClickOutside';
 export { default as useFunnel } from './useFunnel';
+export { default as useDragAndDrop } from './useDragAndDrop';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,4 +12,4 @@ export { default as useOverlayFixed } from './useOverlayFixed';
 export { default as useFilmRecipeImage } from './useFilmRecipeImage';
 export { default as useClickOutside } from './useClickOutside';
 export { default as useFunnel } from './useFunnel';
-export { default as useDragAndDrop } from './useDragAndDrop';
+export { default as useDrag } from './useDrag';

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -3,7 +3,7 @@ import useClickOutside from './useClickOutside';
 
 const DRAG_THRESHOLD = 10; // 픽셀 단위
 
-const useDragAndDrop = () => {
+const useDrag = () => {
 	const [dragX, setDragX] = useState(0);
 	const [dragStartX, setDragStartX] = useState<number | null>(null);
 	const dragRef = useRef<number>(0);
@@ -57,4 +57,4 @@ const useDragAndDrop = () => {
 	};
 };
 
-export default useDragAndDrop;
+export default useDrag;

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -1,0 +1,60 @@
+import { TouchEvent, useRef, useState } from 'react';
+import useClickOutside from './useClickOutside';
+
+const DRAG_THRESHOLD = 10; // 픽셀 단위
+
+const useDragAndDrop = () => {
+	const [dragX, setDragX] = useState(0);
+	const [dragStartX, setDragStartX] = useState<number | null>(null);
+	const dragRef = useRef<number>(0);
+
+	const dragContainerRef = useClickOutside<HTMLLIElement>({
+		eventHandler: () => {
+			setDragX(0);
+			dragRef.current = 0;
+		},
+	});
+
+	// TODO: 리팩토링 필요
+	const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+		setDragStartX(event.touches[0].clientX);
+		dragRef.current = event.touches[0].clientX;
+	};
+
+	const handleTouchMove = (event: TouchEvent<HTMLDivElement>) => {
+		if (dragStartX === null) return;
+
+		const currentX = event.touches[0].clientX;
+		const diff = currentX - dragRef.current; // 현재 위치 - 첫 터치 드래그 시작 위치 (음수)
+
+		// 최소 이동 거리를 넘어선 경우에만 드래그 적용
+		if (Math.abs(diff) > DRAG_THRESHOLD) {
+			const dampingFactor = 0.8;
+			const dragAmount = currentX - dragRef.current;
+			if (dragAmount < 0) {
+				setDragX(Math.max(dampingFactor * dragAmount, -80));
+			}
+		}
+	};
+
+	const handleTouchEnd = () => {
+		const SNAP_THRESHOLD = -40;
+
+		if (dragX < SNAP_THRESHOLD) {
+			setDragX(-80);
+		} else {
+			setDragX(0);
+		}
+
+		setDragStartX(null);
+		dragRef.current = 0;
+	};
+
+	return {
+		dragX,
+		dragContainerRef,
+		handlers: { handleTouchStart, handleTouchMove, handleTouchEnd },
+	};
+};
+
+export default useDragAndDrop;

--- a/src/pages/ExpenseTrackerByMonth.tsx
+++ b/src/pages/ExpenseTrackerByMonth.tsx
@@ -36,7 +36,7 @@ const ExpenseTrackerByMonthPage = () => {
 					NEW
 				</AddPaymentButton>
 			</Header>
-			<DatePicker selected={selected} setSelected={setSelected} />
+			<DatePicker selected={selected} setSelected={setSelected} disabled={{ after: today }} isFloated={true} />
 			<PaymentListLayout>
 				<PaymentListTitle>List</PaymentListTitle>
 				<Flex>
@@ -61,6 +61,7 @@ const Header = styled.div`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	margin-bottom: 16px;
 `;
 
 const Title = styled.h2`

--- a/src/pages/ExpenseTrackerFixedCost.tsx
+++ b/src/pages/ExpenseTrackerFixedCost.tsx
@@ -28,8 +28,6 @@ const ExpenseTrackerFixedCost = () => {
 		queryFn: () => getFixedCostPaymentsByMonth(today.getMonth() - 1),
 	});
 
-	console.log(data);
-
 	const navigate = useNavigate();
 
 	return (

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -78,7 +78,7 @@ const WritePage = () => {
 					<Controller
 						name="tags"
 						control={control}
-						render={({ field: { value, onChange } }) => <TagsInput tags={value} onChange={onChange} />}
+						render={({ field: { name, value, onChange } }) => <TagsInput inputId={name} tags={value} onChange={onChange} />}
 					/>
 				</Wrapper>
 				<UploadButton type="submit">{isLoading ? Loading : 'Upload'}</UploadButton>

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -219,18 +219,26 @@ const Global = css`
 	}
 
 	.rdp-root {
-		position: absolute;
-		top: 60px;
-		background-color: none;
+		margin-top: 8px;
+		background: none;
 		z-index: var(--modal-index);
 		--rdp-accent-color: var(--grey600); /* Change the accent color to indigo. */
 		--rdp-accent-background-color: var(--blue300); /* Change the accent background color. */
 		--rdp-today-color: var(--blue200);
 		--rdp-selected-border: 1px solid var(--blue200);
+
+		@media screen and (min-width: 480px) {
+			--rdp-day-width: calc((var(--max-app-width)- 4 * var(--padding-container-mobile)) / 7);
+			--rdp-day-height: calc((var(--max-app-width)- 4 * var(--padding-container-mobile)) / 7);
+			--rdp-day_button-width: calc((var(--max-app-width) - 4 * var(--padding-container-mobile)) / 7);
+			--rdp-day_button-height: calc((var(--max-app-width) - 4 * var(--padding-container-mobile)) / 7);
+		}
 	}
 
 	.rdp-months {
-		padding: 6px 12px;
+		padding: 8px 16px;
+		min-width: var(--min-app-width);
+		max-width: var(--max-app-width);
 		background-color: var(--white);
 		border: 1px solid var(--grey100);
 		border-radius: var(--radius-m);

--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -143,6 +143,9 @@ export interface Database {
 					content: string;
 					created_at: Date;
 					updated_at: Date;
+					notified: boolean;
+					reminder_time: Date;
+					tags: string[] | null;
 				};
 				Insert: {
 					// the data to be passed to .insert()
@@ -152,6 +155,8 @@ export interface Database {
 					content: string;
 					created_at: Date;
 					updated_at: Date;
+					reminder_time?: Date;
+					tags: string[] | null;
 				};
 				Update: {
 					// the data to be passed to .update()
@@ -161,6 +166,8 @@ export interface Database {
 					content?: string;
 					created_at?: Date;
 					updated_at: Date;
+					reminder_time?: Date;
+					tags: string[] | null;
 				};
 				Delete: {
 					// the data to be passed to .delete()

--- a/src/supabase/schema.ts
+++ b/src/supabase/schema.ts
@@ -1,6 +1,6 @@
 import { Database } from './database.types';
 
-type ServiceDataType = Diary | Recipe | User | null;
+type ServiceDataType = Diary | Recipe | Todo | User | null;
 
 type Diary = Database['public']['Tables']['diary']['Row'];
 type Recipe = Database['public']['Tables']['recipes']['Row'];

--- a/src/supabase/todos.ts
+++ b/src/supabase/todos.ts
@@ -13,12 +13,16 @@ const getTodos = async (): Promise<Todo[]> => {
 	return data;
 };
 
-const addTodo = async (data: Omit<Todo, 'id'>) => {
+const addTodo = async (data: Omit<Todo, 'id' | 'reminder_time' | 'notified' | 'tags'>) => {
 	const { error: addTodoError } = await supabase.from(TABLE).insert(data).select();
 
 	if (addTodoError) {
 		throw new Error(addTodoError.message);
 	}
+};
+
+const editTodoContent = async ({ id, content }: { id: string; content: string }) => {
+	return await supabase.from(TABLE).update({ content }).eq('id', id);
 };
 
 const updatedTodoCompleted = async ({ id, completed, updated_at }: { id: string; completed: boolean; updated_at: Date }) => {
@@ -37,4 +41,4 @@ const removeTodo = async ({ id }: { id: string }) => {
 	}
 };
 
-export { getTodos, addTodo, updatedTodoCompleted, removeTodo };
+export { getTodos, addTodo, editTodoContent, updatedTodoCompleted, removeTodo };


### PR DESCRIPTION
- [x] add variant on `TextInput` for styling different size of `Input`
- [x] abstracted and separated some logic using the `useDrag` hook
- [x] set dynamic `DatePicker`'s position based on `isFloated` prop
  - Originally, `DatePicker` is shown based on `TriggerButton`, but it has 'position:absolute'. It has kinda problem that `DatePicker`'s `DayPicker` doesn't occupy space for itself, floating on top
- [x] add `disabled` prop in `DatePicker` based on parent Component's role (likewise user doesn't allow to pick future dates)
- [x] add name property on input element of `TagsInput`
- [x] develop `TodoItemEditModal` UI and add `ContentEditingForm` based on user click event, like IOS Reminder app's content edit action