### PR TITLE
refactor : normalize `queryKey` format for expense tracker invalidation

### DIFF
--- a/src/components/content/ContentBody.tsx
+++ b/src/components/content/ContentBody.tsx
@@ -10,7 +10,7 @@ import { queryKey } from '../../constants';
 const ContentBody = () => {
 	const { diaryId } = useParams();
 
-	const { data } = useSuspenseQuery({ queryKey: [...queryKey.DIARY, diaryId], queryFn: () => getSingleDiary(diaryId!) });
+	const { data } = useSuspenseQuery({ queryKey: [...queryKey.DIARY, diaryId], queryFn: () => getSingleDiary(diaryId as string) });
 	const { mutate: remove, isPending } = useRemoveDiaryMutation();
 
 	const { setModal } = useModalStore();

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -9,6 +9,7 @@ const routes = {
 	PROFILE: 'profile',
 	TODO_REMINDER: '/todo_reminder',
 	EXPENSE_TRACKER: '/expense',
+	EXPENSE_TRACKER_BY_MONTH: '/expense/daily',
 	UPDATE_PASSWORD: 'update-password',
 } as const;
 

--- a/src/pages/ExpenseTrackerByMonthItem.tsx
+++ b/src/pages/ExpenseTrackerByMonthItem.tsx
@@ -6,7 +6,7 @@ import { BsFillCreditCardFill } from 'react-icons/bs';
 import { Button } from '../components';
 import { useLoading } from '../hooks';
 import { removePayment } from '../supabase';
-import { monetizeWithSeparator, format } from '../utils';
+import { monetizeWithSeparator, format, getNormalizedDateString } from '../utils';
 import { useToastStore } from '../store';
 import { routes, queryKey, toastData } from '../constants';
 
@@ -25,12 +25,12 @@ const ExpenseTrackerByMonthItemPage = () => {
 			await startTransition(removePayment({ id: payment.id }));
 
 			addToast(toastData.EXPENSE_TRACKER.REMOVE.SUCCESS);
-			navigate(routes.EXPENSE_TRACKER, { state: { currentDate } });
+			navigate(routes.EXPENSE_TRACKER_BY_MONTH, { state: { currentDate }, replace: true });
 		} catch (e) {
 			console.error(e);
 			addToast(toastData.EXPENSE_TRACKER.REMOVE.ERROR);
 		} finally {
-			queryClient.invalidateQueries({ queryKey: [...queryKey.EXPENSE_TRACKER, currentDate] });
+			queryClient.invalidateQueries({ queryKey: [...queryKey.EXPENSE_TRACKER, getNormalizedDateString(currentDate)] });
 		}
 	};
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -20,6 +20,10 @@ const getDateFromString = (dateString: string): Date => {
 	return new Date(dateString);
 };
 
+const getNormalizedDateString = (date: Date) => {
+	return date.toISOString().split('T')[0];
+};
+
 const getNextMonthFormatDate = (usageDate: Date) => {
 	const _date = new Date(usageDate);
 	const [month, date] = [_date.getMonth(), _date.getDate()];
@@ -38,5 +42,6 @@ export {
 	format,
 	translateNumberIntoMonth,
 	getDateFromString,
+	getNormalizedDateString,
 	getNextMonthFormatDate,
 };


### PR DESCRIPTION
- normalize `queryKey` format for expense tracker invalidation
  - use `new Date().toISOString().split('T')[0]` on `useSuspenseQuery`'s `queryKey` in `ExpenseTrackerByMonth` page in order to explicitly specify the type
  - change `currentDate` into `getNormalizedDateString(currentDate)` on `ExpenseTrackerByMonthItem` page to **invalidate** queries, to match `queryKey`