### PR TITLE
feat : develop `useTogglePaymentIsFixedMutation` to toggle `isFixed` on `expense_tracker` server state

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@tanstack/react-query": "^5.62.10",
 		"@tanstack/react-query-devtools": "^5.62.10",
 		"date-fns": "^4.1.0",
+		"date-fns-tz": "^3.2.0",
 		"es-toolkit": "^1.31.0",
 		"framer-motion": "^11.15.0",
 		"react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       es-toolkit:
         specifier: ^1.31.0
         version: 1.31.0
@@ -822,6 +825,11 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -2236,6 +2244,10 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
 
   date-fns@4.1.0: {}
 

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -7,7 +7,7 @@ import { ko } from 'date-fns/locale';
 import { Button } from '..';
 import { useClickOutside } from '../../hooks';
 import { customPropReceiver } from '../../constants';
-import { format } from '../../utils';
+import { formatByKoreanTime } from '../../utils';
 
 interface DatePickerProps {
 	selected: Date | undefined;
@@ -28,7 +28,7 @@ const DatePicker = ({ selected, setSelected, error, disabled, isFloated = false,
 				<IconBackground>
 					<IoMdCalendar size="24" color="var(--grey800)" />
 				</IconBackground>
-				<span>{selected ? format(selected) : 'Select Date'}</span>
+				<span>{selected ? formatByKoreanTime(selected) : 'Select Date'}</span>
 			</TriggerButton>
 			{error && <ErrorMessage>﹡ {error?.message}</ErrorMessage>}
 			<DayPickerWrapper isFloated={isFloated}>

--- a/src/components/common/Switch.tsx
+++ b/src/components/common/Switch.tsx
@@ -1,20 +1,27 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
+import { debounce } from 'es-toolkit';
 
 interface SwitchProps {
 	initialValue: boolean;
+	toggle: (newState: boolean) => void;
 }
 
-const Switch = ({ initialValue }: SwitchProps) => {
-	const [isToggle, setIsToggle] = useState(initialValue);
+const Switch = ({ initialValue, toggle }: SwitchProps) => {
+	const [isActive, setIsActive] = useState(initialValue);
+
+	const handleSwitchToggle = (newState: boolean) => {
+		setIsActive(newState);
+
+		const debouncedServerUpdate = debounce(isActive => toggle(isActive), 200);
+
+		debouncedServerUpdate(newState);
+	};
 
 	return (
-		<Container
-			onClick={() => {
-				setIsToggle(!isToggle);
-			}}>
-			<Trigger isToggle={isToggle} />
-			<Background isToggle={isToggle} />
+		<Container onClick={() => handleSwitchToggle(!isActive)}>
+			<Trigger isActive={isActive} />
+			<Background isActive={isActive} />
 		</Container>
 	);
 };
@@ -26,10 +33,10 @@ const Container = styled.div`
 	cursor: pointer;
 `;
 
-const Trigger = styled.button<{ isToggle: boolean }>`
+const Trigger = styled.button<{ isActive: boolean }>`
 	position: absolute;
 	top: 3px;
-	left: ${({ isToggle }) => (isToggle ? '26px' : '2px')};
+	left: ${({ isActive }) => (isActive ? '26px' : '2px')};
 	width: 20px;
 	height: 20px;
 	background-color: var(--white);
@@ -38,10 +45,10 @@ const Trigger = styled.button<{ isToggle: boolean }>`
 	transition: left calc(0.2 * 1s);
 `;
 
-const Background = styled.div<{ isToggle: boolean }>`
+const Background = styled.div<{ isActive: boolean }>`
 	display: flex;
 	height: 100%;
-	background-color: ${({ isToggle }) => (isToggle ? 'var(--black)' : 'var(--grey300)')};
+	background-color: ${({ isActive }) => (isActive ? 'var(--black)' : 'var(--grey300)')};
 	border-radius: var(--radius-extra);
 	box-shadow: 2px 2px 5px 0 rgba(50, 50, 50, 0.25);
 	transition: background calc(0.2 * 1s);

--- a/src/components/expenseTracker/PaymentList.tsx
+++ b/src/components/expenseTracker/PaymentList.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { EmptyMessage, PaymentItem } from '..';
 import { ExtendedPaymentMethodType } from '../../pages/ExpenseTrackerByMonth';
 import { getPaymentsByDate } from '../../supabase';
-import { monetizeWithSeparator } from '../../utils';
+import { formatByKoreanTime, monetizeWithSeparator } from '../../utils';
 import { PriceUnitType, staleTime, queryKey } from '../../constants';
 
 interface PaymentListProps {
@@ -14,19 +14,17 @@ interface PaymentListProps {
 }
 
 const PaymentList = ({ selectedDate, currentPaymentMethod, currentPriceUnit }: PaymentListProps) => {
-	const normalizedDateString = selectedDate.toISOString().split('T')[0]; // prevent unnecessary fetch because of milliseconds difference because of changing ISO string itself (make regularize -'YYYY-MM-DD')
-
 	const {
-		data: { data, totalPrice },
+		data: { expense, totalPrice },
 	} = useSuspenseQuery({
-		queryKey: [...queryKey.EXPENSE_TRACKER, normalizedDateString],
+		queryKey: [...queryKey.EXPENSE_TRACKER, formatByKoreanTime(selectedDate)],
 		queryFn: () => getPaymentsByDate(selectedDate),
 		staleTime: staleTime.EXPENSE_TRACKER.BY_MONTH,
 	});
 
 	const navigate = useNavigate();
 
-	const filteredData = data.filter(
+	const filteredData = expense?.filter(
 		({ payment_method, price_unit }) =>
 			(currentPaymentMethod === 'All' || payment_method === currentPaymentMethod) && price_unit === currentPriceUnit,
 	);

--- a/src/components/modal/todoReminder/TodoItemEditModal.tsx
+++ b/src/components/modal/todoReminder/TodoItemEditModal.tsx
@@ -7,7 +7,7 @@ import { isEqual } from 'es-toolkit';
 import { ModalLayout, ModalDataType } from '..';
 import { Button, DatePicker, TagsInput, TextInput, editTodoItemFormSchema, EditTodoItemFormSchema, LoadingSpinner } from '../..';
 import { editTodoDetail, type Todo } from '../../../supabase';
-import { format, today } from '../../../utils';
+import { formatByKoreanTime, today } from '../../../utils';
 import { useToastStore } from '../../../store';
 import { useLoading, useRemoveTodoItemMutation } from '../../../hooks';
 import { queryKey, toastData } from '../../../constants';
@@ -55,8 +55,8 @@ const TodoItemEditModal = ({ id: modalId, type, onClose, data: { id, content, ta
 		if (
 			reminder_time
 				? isEqual(
-						{ content: formData.content, reminder_time: format(formData.reminder_time) },
-						{ content, reminder_time: format(reminder_time) },
+						{ content: formData.content, reminder_time: formatByKoreanTime(formData.reminder_time) },
+						{ content, reminder_time: formatByKoreanTime(reminder_time) },
 						// eslint-disable-next-line no-mixed-spaces-and-tabs
 				  )
 				: false

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -88,6 +88,13 @@ const toastData = {
 			SUCCESS: { status: 'success', message: `Add payment ${FIXED_SUCCESS_PHRASE}` },
 			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} adding` },
 		},
+		TOGGLE: {
+			SUCCESS: { status: 'success', message: `Set next month upcoming cost ${FIXED_SUCCESS_PHRASE}` },
+			ERROR: {
+				status: 'error',
+				message: `${FIXED_ERROR_MESSAGE_PHRASE} setting fixed`,
+			},
+		},
 		REMOVE: {
 			SUCCESS: { status: 'success', message: `Delete ${FIXED_SUCCESS_PHRASE}` },
 			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} deleting` },

--- a/src/hooks/mutations/diary/useAddDiaryMutation.ts
+++ b/src/hooks/mutations/diary/useAddDiaryMutation.ts
@@ -9,6 +9,7 @@ const add = (data: Diary) => (oldData: Diary[]) => {
 // 현재 상황에서는 별도의 페이지에서 작성하고 있기 때문에, mutation이 필요 없을 수 있음
 const useAddDiaryMutation = () => {
 	const queryClient = useQueryClient();
+	const QUERY_KEY = queryKey.DIARY_BY_PAGE;
 
 	const { mutate } = useMutation({
 		mutationFn: async (variables: Diary) => {
@@ -17,11 +18,11 @@ const useAddDiaryMutation = () => {
 		async onMutate(variables) {
 			// Cancel any outgoing refetch
 			// (so they don't overwrite our optimistic update)
-			await queryClient.cancelQueries({ queryKey: queryKey.DIARY_BY_PAGE });
-			const previousData = queryClient.getQueryData(queryKey.DIARY_BY_PAGE);
+			await queryClient.cancelQueries({ queryKey: QUERY_KEY });
+			const previousData = queryClient.getQueryData(QUERY_KEY);
 
 			if (previousData) {
-				queryClient.setQueryData(queryKey.DIARY_BY_PAGE, add(variables));
+				queryClient.setQueryData(QUERY_KEY, add(variables));
 			}
 
 			return { previousData };
@@ -31,12 +32,12 @@ const useAddDiaryMutation = () => {
 		onError(error, _, context) {
 			if (context?.previousData) {
 				console.error(error);
-				queryClient.setQueryData(queryKey.DIARY_BY_PAGE, context?.previousData);
+				queryClient.setQueryData(QUERY_KEY, context?.previousData);
 			}
 		},
 		// Always refetch after error or success:
 		onSettled() {
-			return queryClient.invalidateQueries({ queryKey: queryKey.DIARY_BY_PAGE });
+			return queryClient.invalidateQueries({ queryKey: QUERY_KEY });
 		},
 	});
 	return mutate;

--- a/src/hooks/mutations/expenseTracker/index.ts
+++ b/src/hooks/mutations/expenseTracker/index.ts
@@ -1,0 +1,1 @@
+export { default as useTogglePaymentIsFixedMutation } from './useTogglePaymentIsFixedMutation';

--- a/src/hooks/mutations/expenseTracker/useTogglePaymentIsFixedMutation.ts
+++ b/src/hooks/mutations/expenseTracker/useTogglePaymentIsFixedMutation.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ExpenseTracker, PaymentsByDate, togglePaymentIsFixed } from '../../../supabase';
+import { useToastStore } from '../../../store';
+import { toastData, queryKey } from '../../../constants';
+import { formatByKoreanTime } from '../../../utils';
+
+interface UseTogglePaymentIsFixedMutation {
+	currentDate: Date;
+	handlers: { [key: string]: () => void };
+}
+
+type Variables = Pick<ExpenseTracker, 'id' | 'isFixed' | 'updated_at'>;
+
+const toggle =
+	({ id, isFixed }: Variables) =>
+	(oldData: PaymentsByDate) => {
+		return { ...oldData, expense: oldData.expense.map(item => (item.id === id ? { ...item, isFixed } : item)) };
+	};
+
+const useTogglePaymentIsFixedMutation = ({ currentDate, handlers: { goBack } }: UseTogglePaymentIsFixedMutation) => {
+	const queryClient = useQueryClient();
+	const { addToast } = useToastStore();
+	const QUERY_KEY = [...queryKey.EXPENSE_TRACKER, formatByKoreanTime(currentDate)];
+
+	return useMutation({
+		async mutationFn(variables: Variables) {
+			await togglePaymentIsFixed(variables);
+		},
+		async onMutate(variables) {
+			await queryClient.cancelQueries({ queryKey: QUERY_KEY });
+
+			const previousData = queryClient.getQueryData(QUERY_KEY);
+
+			if (previousData) {
+				queryClient.setQueryData(QUERY_KEY, toggle(variables));
+			}
+
+			return { previousData };
+		},
+
+		onSuccess() {
+			addToast(toastData.EXPENSE_TRACKER.TOGGLE.SUCCESS);
+			goBack();
+		},
+
+		onError(error, _, context) {
+			if (context?.previousData) {
+				console.error(error);
+				queryClient.setQueryData(QUERY_KEY, context?.previousData);
+				addToast(toastData.EXPENSE_TRACKER.TOGGLE.ERROR);
+			}
+		},
+		onSettled() {
+			return queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+		},
+	});
+};
+
+export default useTogglePaymentIsFixedMutation;

--- a/src/hooks/mutations/filmRecipe/useRemoveFilmRecipeMutation.ts
+++ b/src/hooks/mutations/filmRecipe/useRemoveFilmRecipeMutation.ts
@@ -2,30 +2,28 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { removeRecipe, RestrictedRecipe } from '../../../supabase';
 import { toastData, queryKey } from '../../../constants';
 import { useToastStore } from '../../../store';
+import { Handlers } from '../../../types';
 
 interface UseRemoveFilmRecipeMutation {
 	id: string;
-	handlers: {
-		onClose: () => void;
-		onTopLevelModalClose: () => void;
-	};
+	handlers: Handlers;
 }
 
+type Variables = Pick<RestrictedRecipe, 'id'> & { path: string };
+
 const remove =
-	({ id }: { id: string }) =>
+	({ id }: Variables) =>
 	(oldData: RestrictedRecipe[]) => {
 		return oldData.filter(item => item.id !== id);
 	};
 
-const useRemoveRecipeMutation = ({ id, handlers }: UseRemoveFilmRecipeMutation) => {
+const useRemoveRecipeMutation = ({ id, handlers: { onClose, onTopLevelModalClose } }: UseRemoveFilmRecipeMutation) => {
 	const queryClient = useQueryClient();
 	const { addToast } = useToastStore();
-	const { onClose, onTopLevelModalClose } = handlers;
-
 	const QUERY_KEY = [...queryKey.FILM_RECIPE, id];
 
-	const { mutate, isPending } = useMutation({
-		async mutationFn(variables: { id: string; path: string }) {
+	return useMutation({
+		async mutationFn(variables: Variables) {
 			await removeRecipe(variables);
 		},
 		async onMutate(variables) {
@@ -59,8 +57,6 @@ const useRemoveRecipeMutation = ({ id, handlers }: UseRemoveFilmRecipeMutation) 
 			return queryClient.invalidateQueries({ queryKey: queryKey.FILM_RECIPE });
 		},
 	});
-
-	return { mutate, isPending };
 };
 
 export default useRemoveRecipeMutation;

--- a/src/hooks/mutations/index.ts
+++ b/src/hooks/mutations/index.ts
@@ -1,3 +1,4 @@
 export * from './diary';
+export * from './expenseTracker';
 export * from './filmRecipe';
 export * from './todoReminder';

--- a/src/hooks/mutations/todoReminder/useRemoveTodoItemMutation.ts
+++ b/src/hooks/mutations/todoReminder/useRemoveTodoItemMutation.ts
@@ -3,9 +3,7 @@ import { useToastStore } from '../../../store';
 import { removeTodo, Todo } from '../../../supabase';
 import { queryKey, toastData } from '../../../constants';
 
-interface Variables {
-	id: string;
-}
+type Variables = Pick<Todo, 'id'>;
 
 const remove =
 	({ id }: Variables) =>
@@ -16,17 +14,18 @@ const remove =
 const useRemoveTodoItemMutation = (handler?: () => void) => {
 	const queryClient = useQueryClient();
 	const { addToast } = useToastStore();
+	const QUERY_KEY = queryKey.TODOS;
 
 	return useMutation({
 		async mutationFn(variables: Variables) {
 			await removeTodo(variables);
 		},
 		async onMutate(variables) {
-			await queryClient.cancelQueries({ queryKey: queryKey.TODOS });
-			const previousData = queryClient.getQueryData(queryKey.TODOS);
+			await queryClient.cancelQueries({ queryKey: QUERY_KEY });
+			const previousData = queryClient.getQueryData(QUERY_KEY);
 
 			if (previousData) {
-				queryClient.setQueryData(queryKey.TODOS, remove(variables));
+				queryClient.setQueryData(QUERY_KEY, remove(variables));
 			}
 
 			return { previousData };
@@ -36,7 +35,7 @@ const useRemoveTodoItemMutation = (handler?: () => void) => {
 				console.error(error);
 
 				addToast(toastData.TODO_REMINDER.REMOVE.ERROR);
-				queryClient.setQueryData(queryKey.TODOS, context?.previousData);
+				queryClient.setQueryData(QUERY_KEY, context?.previousData);
 			}
 		},
 		onSuccess() {
@@ -44,7 +43,7 @@ const useRemoveTodoItemMutation = (handler?: () => void) => {
 			handler?.();
 		},
 		onSettled() {
-			return queryClient.invalidateQueries({ queryKey: queryKey.TODOS });
+			return queryClient.invalidateQueries({ queryKey: QUERY_KEY });
 		},
 	});
 };

--- a/src/hooks/mutations/todoReminder/useUpdateTodoItemCompletedMutation.ts
+++ b/src/hooks/mutations/todoReminder/useUpdateTodoItemCompletedMutation.ts
@@ -3,11 +3,7 @@ import { Todo, updatedTodoCompleted } from '../../../supabase';
 import { queryKey, toastData } from '../../../constants';
 import { useToastStore } from '../../../store';
 
-interface Variables {
-	id: string;
-	completed: boolean;
-	updated_at: Date;
-}
+type Variables = Pick<Todo, 'id' | 'completed' | 'updated_at'>;
 
 const update =
 	({ id, completed, updated_at }: Variables) =>
@@ -18,17 +14,18 @@ const update =
 const useUpdateTodoItemCompletedMutation = () => {
 	const queryClient = useQueryClient();
 	const { addToast } = useToastStore();
+	const QUERY_KEY = queryKey.TODOS;
 
 	return useMutation({
 		async mutationFn(variables: Variables) {
 			await updatedTodoCompleted(variables);
 		},
 		async onMutate(variables) {
-			await queryClient.cancelQueries({ queryKey: queryKey.TODOS });
-			const previousData = queryClient.getQueryData(queryKey.TODOS);
+			await queryClient.cancelQueries({ queryKey: QUERY_KEY });
+			const previousData = queryClient.getQueryData(QUERY_KEY);
 
 			if (previousData) {
-				queryClient.setQueryData(queryKey.TODOS, update(variables));
+				queryClient.setQueryData(QUERY_KEY, update(variables));
 			}
 
 			return { previousData };
@@ -38,14 +35,14 @@ const useUpdateTodoItemCompletedMutation = () => {
 				console.error(error);
 
 				addToast(toastData.TODO_REMINDER.EDIT.ERROR);
-				queryClient.setQueryData(queryKey.TODOS, context?.previousData);
+				queryClient.setQueryData(QUERY_KEY, context?.previousData);
 			}
 		},
 		onSuccess() {
 			addToast(toastData.TODO_REMINDER.EDIT.SUCCESS);
 		},
 		onSettled() {
-			return queryClient.invalidateQueries({ queryKey: queryKey.TODOS });
+			return queryClient.invalidateQueries({ queryKey: QUERY_KEY });
 		},
 	});
 };

--- a/src/pages/ExpenseTrackerByMonthItem.tsx
+++ b/src/pages/ExpenseTrackerByMonthItem.tsx
@@ -39,7 +39,6 @@ const ExpenseTrackerByMonthItemPage = () => {
 		}
 	};
 
-	// TODO: edit Switch to toggle Upcoming Next Month with `payment.isFixed`
 	return (
 		<Container>
 			<MainContent>

--- a/src/pages/ExpenseTrackerByMonthItem.tsx
+++ b/src/pages/ExpenseTrackerByMonthItem.tsx
@@ -4,9 +4,9 @@ import { useQueryClient } from '@tanstack/react-query';
 import { FaWonSign } from 'react-icons/fa6';
 import { BsFillCreditCardFill } from 'react-icons/bs';
 import { Button, Switch } from '../components';
-import { useLoading } from '../hooks';
+import { useLoading, useTogglePaymentIsFixedMutation } from '../hooks';
 import { removePayment } from '../supabase';
-import { monetizeWithSeparator, format, getNormalizedDateString } from '../utils';
+import { monetizeWithSeparator, formatByKoreanTime } from '../utils';
 import { useToastStore } from '../store';
 import { routes, queryKey, toastData } from '../constants';
 
@@ -16,9 +16,14 @@ const ExpenseTrackerByMonthItemPage = () => {
 		state: { payment, currentDate },
 	} = useLocation();
 
+	const navigate = useNavigate();
 	const { startTransition, Loading, isLoading } = useLoading();
 	const { addToast } = useToastStore();
-	const navigate = useNavigate();
+
+	const { mutate: toggleIsFixed } = useTogglePaymentIsFixedMutation({
+		currentDate,
+		handlers: { goBack: () => navigate(routes.EXPENSE_TRACKER_BY_MONTH, { replace: true, state: { currentDate: new Date(currentDate) } }) },
+	});
 
 	const handlePaymentDelete = async () => {
 		try {
@@ -30,7 +35,7 @@ const ExpenseTrackerByMonthItemPage = () => {
 			console.error(e);
 			addToast(toastData.EXPENSE_TRACKER.REMOVE.ERROR);
 		} finally {
-			queryClient.invalidateQueries({ queryKey: [...queryKey.EXPENSE_TRACKER, getNormalizedDateString(currentDate)] });
+			queryClient.invalidateQueries({ queryKey: [...queryKey.EXPENSE_TRACKER, formatByKoreanTime(currentDate)] });
 		}
 	};
 
@@ -64,12 +69,15 @@ const ExpenseTrackerByMonthItemPage = () => {
 				</DetailGroup>
 				<DetailGroup>
 					<dt>Transaction Date</dt>
-					<dd>{format(currentDate)}</dd>
+					<dd>{formatByKoreanTime(currentDate)}</dd>
 				</DetailGroup>
 				<DetailGroup>
 					<dt>Make Upcoming Next Month</dt>
 					<dd>
-						<Switch initialValue={payment.isFixed} />
+						<Switch
+							initialValue={payment.isFixed}
+							toggle={(newState: boolean) => toggleIsFixed({ id: payment.id, isFixed: newState, updated_at: new Date() })}
+						/>
 					</dd>
 				</DetailGroup>
 			</Detail>

--- a/src/pages/UpdateProfile.tsx
+++ b/src/pages/UpdateProfile.tsx
@@ -7,7 +7,7 @@ import { Button, ShrinkMotionBlock, MODAL_CONFIG } from '../components';
 import { supabase } from '../supabase';
 import { useLoading } from '../hooks';
 import { useToastStore, useModalStore, useUserStore } from '../store';
-import { format } from '../utils';
+import { formatByKoreanTime } from '../utils';
 import { toastData, routes } from '../constants';
 
 const UpdateProfile = () => {
@@ -72,7 +72,7 @@ const UpdateProfile = () => {
 				</Email>
 				<JoinedDate>
 					<Label>Join in</Label>
-					<dd>{format(new Date(user?.created_at))}</dd>
+					<dd>{formatByKoreanTime(user?.created_at)}</dd>
 				</JoinedDate>
 			</UserInfo>
 

--- a/src/supabase/expenseTracker.ts
+++ b/src/supabase/expenseTracker.ts
@@ -42,7 +42,9 @@ const calculatePriceUnits = (data: ExpenseTracker[]) => {
 	return priceUnits;
 };
 
-const getPaymentsByDate = async (date: Date): Promise<{ data: ExpenseTracker[]; totalPrice: number | Record<string, number> }> => {
+type PaymentsByDate = { expense: ExpenseTracker[]; totalPrice: number | Record<string, number> };
+
+const getPaymentsByDate = async (date: Date): Promise<PaymentsByDate> => {
 	const startOfDay = new Date(date);
 	startOfDay.setHours(0, 0, 0, 0);
 
@@ -59,7 +61,7 @@ const getPaymentsByDate = async (date: Date): Promise<{ data: ExpenseTracker[]; 
 		throw new Error(error.message);
 	}
 
-	return { data, totalPrice: data.length ? calculatePriceUnits(data) : ZERO_PRICE };
+	return { expense: data, totalPrice: data.length ? calculatePriceUnits(data) : ZERO_PRICE };
 };
 
 const getAllPaymentsByMonth = async (month: number) => {
@@ -100,8 +102,17 @@ const addPayment = async (data: Omit<ExpenseTracker, 'id' | 'isFixed'>) => {
 	}
 };
 
+const togglePaymentIsFixed = async ({ id, isFixed }: { id: string; isFixed: boolean }) => {
+	const { error } = await supabase.from(TABLE).update({ isFixed }).eq('id', id);
+
+	if (error) {
+		throw new Error(error.message);
+	}
+};
+
 const removePayment = async ({ id }: { id: string }) => {
 	await supabase.from(TABLE).delete().eq('id', id);
 };
 
-export { getPaymentsByDate, getAllPaymentsByMonth, getFixedCostPaymentsByMonth, addPayment, removePayment };
+export type { PaymentsByDate };
+export { getPaymentsByDate, getAllPaymentsByMonth, getFixedCostPaymentsByMonth, addPayment, togglePaymentIsFixed, removePayment };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './mutation';

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -1,0 +1,5 @@
+type Handlers = {
+	[handler: string]: () => void;
+};
+
+export type { Handlers };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -9,7 +9,6 @@ const [currentYear, currentMonth, currentDate] = [today.getFullYear(), today.get
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const;
 
 const formatByKoreanTime = (targetDate: Date | string): string => {
-	// 현재 시간을 가져옵니다
 	const _date = typeof targetDate === 'string' ? new Date(targetDate) : targetDate;
 
 	const koreaTimeZone = 'Asia/Seoul';

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,4 @@
+import { format, toZonedTime } from 'date-fns-tz';
 const today = new Date();
 const todayLocaleString = today.toLocaleString('en-US', { timeZone: 'Asia/Seoul' });
 
@@ -7,11 +8,16 @@ const [currentYear, currentMonth, currentDate] = [today.getFullYear(), today.get
 
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const;
 
-const format = (targetDate: Date): string => {
-	const _date = new Date(targetDate);
-	const [year, month, date] = [_date.getFullYear(), _date.getMonth() + 1, _date.getDate()];
+const formatByKoreanTime = (targetDate: Date | string): string => {
+	// 현재 시간을 가져옵니다
+	const _date = typeof targetDate === 'string' ? new Date(targetDate) : targetDate;
 
-	return `${year + ''}.${(month + '').padStart(2, '0')}.${(date + '').padStart(2, '0')}`;
+	const koreaTimeZone = 'Asia/Seoul';
+	const koreaDate = toZonedTime(_date, koreaTimeZone);
+
+	const formattedDate = format(koreaDate, 'yyyy/MM/dd', { timeZone: koreaTimeZone });
+
+	return formattedDate;
 };
 
 const translateNumberIntoMonth = (month: number) => months[month]; // ['Jan', 'Feb', 'Mar'][number]
@@ -39,7 +45,7 @@ export {
 	currentMonth,
 	currentDate,
 	months,
-	format,
+	formatByKoreanTime,
 	translateNumberIntoMonth,
 	getDateFromString,
 	getNormalizedDateString,


### PR DESCRIPTION
- add `date-fns-tz` package to match time format as specific timezone
- fix time format problem on `queryKey`
   - Use `date` on `useSuspenseQuery`'s queryKey to track and cache the specific date's data
   
     ```tsx
     const {data: { expense, totalPrice }} = useSuspenseQuery({
		queryKey: [...queryKey.EXPENSE_TRACKER, formatByKoreanTime(selectedDate)],
		queryFn: () => getPaymentsByDate(selectedDate),
		staleTime: staleTime.EXPENSE_TRACKER.BY_MONTH });

   - Previous : Used just UTC date format on `queryKey`
   - Now : use `date-fns-tz` 's format function to format as proper time format
   
     ```tsx
     const formatByKoreanTime = (targetDate: Date | string): string => {
        const _date = typeof targetDate === 'string' ? new Date(targetDate) : targetDate;
        const koreaTimeZone = 'Asia/Seoul';
        const koreaDate = toZonedTime(_date, koreaTimeZone);
        const formattedDate = format(koreaDate, 'yyyy/MM/dd', { timeZone: koreaTimeZone });
        return formattedDate;
     };


- develop `Switch` UI
- use `debounce` to prevent user from toggling server state continuously and stop to send unnecessary request
- add `Handlers` type using Mapped types
- organize type `Variables` and `mutation`s parameters` type

