### PR TITLE
feat : add vite's `rollupOptions` to reduce bundle size

### DIFF
--- a/src/components/modal/ModalLayout.tsx
+++ b/src/components/modal/ModalLayout.tsx
@@ -103,9 +103,10 @@ const CloseButton = styled(Button)`
 const Body = styled.div`
 	max-height: calc(100dvh - var(--nav-height) * 3);
 	overflow-y: scroll;
+
 	scrollbar-width: none; // Firefox
 	&::-webkit-scrollbar {
-		display: none; // 스크롤바 숨기기 (선택사항)
+		display: none; // hide scrollbar
 	}
 `;
 

--- a/src/components/modal/expenseTracker/AddPaymentModal.tsx
+++ b/src/components/modal/expenseTracker/AddPaymentModal.tsx
@@ -31,9 +31,8 @@ const AddPaymentModal = ({ id, type, onClose }: AddPaymentModalProps) => {
 		formState: { errors, touchedFields },
 	} = useForm<AddPaymentFormSchema>({
 		resolver: zodResolver(addPaymentFormSchema),
-		defaultValues: { usage_date: today, installment_plan_months: null },
+		defaultValues: { usage_date: today, card_type: cardType['미확인'], installment_plan_months: null },
 	});
-
 	const { startTransition, Loading, isLoading } = useLoading();
 	const { addToast } = useToastStore();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,32 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+	plugins: [react()],
+	build: {
+		rollupOptions: {
+			output: {
+				manualChunks(id: string) {
+					// Reducing the vendor chunk size
+					// creating a chunk to react routes deps. Reducing the vendor chunk size
+					if (id.includes('react-router-dom') || id.includes('@remix-run') || id.includes('react-router')) {
+						return '@react-router';
+					}
+
+					if (id.includes('supabase/supabase-js')) {
+						return '@supabase';
+					}
+
+					if (id.includes('framer-motion')) {
+						return '@motion';
+					}
+
+					if (id.includes('zod')) {
+						return '@zod';
+					}
+				},
+			},
+		},
+	},
+});


### PR DESCRIPTION
- fix that `onSubmit` is not working when payment_method is 'cash' on `AddPaymentModal` component
  - if `payment_method` is `cash`, `card_type` must be 'Unconfirmed`
  - should set `cardType` of defaultValues as 'Unconfirmed', because if user select 'cash', cardType `CustomSelect` will not appear on Screen
- add vite's `rollupOptions` to reduce bundle size
  - @react-router-dom, @react-router, @remix-run, @supabase/supabase-js, @framer-motion, and @zod