### PR TITLE
feat : add type of `CommuteRecords` and add thousand comma on `recharts` component

### DIFF
--- a/src/components/expenseTracker/ExpenseChart.tsx
+++ b/src/components/expenseTracker/ExpenseChart.tsx
@@ -46,6 +46,7 @@ const ExpenseChart = ({ selectMonth }: ExpenseChartProps) => {
 						<CartesianGrid stroke="var(--grey200)" strokeDasharray="3 3" />
 						<Tooltip
 							labelFormatter={label => `${label}일`}
+							formatter={(value: number) => [monetizeWithSeparator(value), 'price']}
 							wrapperStyle={{
 								border: 'none',
 								backgroundColor: 'var(--background)',

--- a/src/supabase/schema.ts
+++ b/src/supabase/schema.ts
@@ -7,6 +7,7 @@ type Recipe = Database['public']['Tables']['recipes']['Row'];
 type Todo = Database['public']['Tables']['todos']['Row'];
 type ExpenseTracker = Database['public']['Tables']['expense_tracker']['Row'];
 type User = Database['public']['Tables']['users']['Row'];
+type CommuteRecords = Database['public']['Tables']['commute_records']['Row'];
 
 interface RestrictedRecipe extends Recipe {
 	dynamic_range: 'DR-Auto' | `DR-${'number'}`;
@@ -31,4 +32,5 @@ export type {
 	Todo,
 	ExpenseTracker,
 	User,
+	CommuteRecords,
 };


### PR DESCRIPTION
- add `CommuteRecords` type on `schema.ts`
- add `formatWithThousandSeparator` function to `recharts` Tooltip Component
  - display commas for thousands in price values on chart