### PR TITLE
feat : develop `EditPaymentModal` and `editPaymentPlace`

### DIFF
--- a/src/components/expenseTracker/PaymentItemDetail.tsx
+++ b/src/components/expenseTracker/PaymentItemDetail.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import { RiArrowRightSLine } from 'react-icons/ri';
+import { MODAL_CONFIG, ShrinkMotionBlock } from '..';
+import { useModalStore } from '../../store';
+import { ExpenseTracker, ServiceDataType } from '../../supabase';
+
+interface PaymentItemDetailProps {
+	title: string;
+	description: string;
+	data: ServiceDataType<ExpenseTracker, { transaction_date: Date }>;
+}
+
+const PaymentItemDetail = ({ title, description, data }: PaymentItemDetailProps) => {
+	const { setModal } = useModalStore();
+
+	const handleEditPaymentModal = () => {
+		setModal({
+			Component: MODAL_CONFIG.EXPENSE_TRACKER.EDIT.Component,
+			props: {
+				type: MODAL_CONFIG.EXPENSE_TRACKER.EDIT.type,
+				data,
+			},
+		});
+	};
+
+	return (
+		<Container onClick={handleEditPaymentModal}>
+			<dt>{title}</dt>
+			<dd>
+				<span>{description}</span>
+				<RiArrowRightSLine size="21" />
+			</dd>
+		</Container>
+	);
+};
+
+const Container = styled(ShrinkMotionBlock)`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: var(--padding-container-mobile);
+	background-color: var(--greyOpacity50);
+	border: 1px solid var(--grey100);
+	border-radius: var(--radius-m);
+	cursor: pointer;
+
+	dt {
+		font-weight: var(--fw-medium);
+		color: var(--grey800);
+	}
+
+	dd {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: var(--fz-h7);
+		font-weight: var(--fw-semibold);
+	}
+`;
+
+export default PaymentItemDetail;

--- a/src/components/expenseTracker/index.ts
+++ b/src/components/expenseTracker/index.ts
@@ -4,6 +4,7 @@ export { default as CreditCardTransactionList } from './CreditCardTransactionLis
 export { default as ExpenseChart } from './ExpenseChart';
 export { default as FixedCostList } from './FixedCostList';
 export { default as FixedCostTotalPrice } from './FixedCostTotalPrice';
-export { default as PaymentList } from './PaymentList';
 export { default as PaymentItem } from './PaymentItem';
+export { default as PaymentItemDetail } from './PaymentItemDetail';
+export { default as PaymentList } from './PaymentList';
 export { default as TotalExpensePrice } from './TotalExpensePrice';

--- a/src/components/modal/commuteRecords/RecordModal.tsx
+++ b/src/components/modal/commuteRecords/RecordModal.tsx
@@ -1,13 +1,11 @@
 import styled from '@emotion/styled';
-import { Session } from '@supabase/supabase-js';
-import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ModalDataType, ModalLayout } from '..';
 import { StatusSelect, Button, TextInput } from '../..';
 import { recordSchema, RecordSchema } from './schema';
 import { addCommute, CommuteRecord, ServiceDataType } from '../../../supabase';
-import { useLoading } from '../../../hooks';
+import { useClientSession, useLoading } from '../../../hooks';
 import { useToastStore } from '../../../store';
 import { queryKey, status, toastData } from '../../../constants';
 
@@ -30,9 +28,18 @@ interface RecordModalProps {
 
 // TODO: add & Edit 을 조건부로 같은 RecordModal 활용?
 
+/**
+ *
+ * 조건부 렌더링 시 차이
+ * - 'add' | 'edit'
+ * - id type data
+ * - defaultValues
+ * - handleSubmit
+ * - form 하위 elements
+ */
+
 const RecordModal = ({ id, type, data: serviceData, onClose }: RecordModalProps) => {
-	const queryClient = useQueryClient();
-	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+	const { queryClient, session } = useClientSession();
 
 	const {
 		register,

--- a/src/components/modal/commuteRecords/schema.ts
+++ b/src/components/modal/commuteRecords/schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { status } from '../../../constants';
+import { commuteStatusList } from '../../../constants';
 
 type RecordSchema = z.infer<typeof recordSchema>;
 
-const statusSchema = z.enum(status, {
+const statusSchema = z.enum(commuteStatusList, {
 	errorMap: () => {
-		return { message: 'Please select work status ' };
+		return { message: 'Please select work status' };
 	},
 });
 

--- a/src/components/modal/expenseTracker/AddPaymentModal.tsx
+++ b/src/components/modal/expenseTracker/AddPaymentModal.tsx
@@ -1,13 +1,11 @@
 import styled from '@emotion/styled';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
-import { Session } from '@supabase/supabase-js';
 import { ModalLayout, ModalDataType } from '..';
 import { AddPaymentFormSchema, addPaymentFormSchema } from '.';
 import { Button, CustomSelect, DatePicker, TextInput } from '../..';
 import { addPayment, ExpenseTracker } from '../../../supabase';
-import { useLoading } from '../../../hooks';
+import { useClientSession, useLoading } from '../../../hooks';
 import { paymentData, toastData, installmentPlanMonths, cardType, queryKey } from '../../../constants';
 import { useToastStore } from '../../../store';
 import { monetizeWithSeparator, today } from '../../../utils';
@@ -20,8 +18,7 @@ interface AddPaymentModalProps {
 }
 
 const AddPaymentModal = ({ id, type, data, onClose }: AddPaymentModalProps) => {
-	const queryClient = useQueryClient();
-	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+	const { queryClient, session } = useClientSession();
 
 	const {
 		register,

--- a/src/components/modal/expenseTracker/EditPaymentModal.tsx
+++ b/src/components/modal/expenseTracker/EditPaymentModal.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from 'react';
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { editPaymentFormSchema, EditPaymentFormSchema, ModalDataType, ModalLayout } from '..';
+import { Button, LabelInput } from '../..';
+import { editPaymentPlace, ExpenseTracker, ServiceDataType } from '../../../supabase';
+import { useLoading } from '../../../hooks';
+import { useToastStore } from '../../../store';
+import { queryKey, routes, toastData } from '../../../constants';
+import { formatByKoreanTime } from '../../../utils';
+
+interface EditPaymentModalProps {
+	id: string;
+	type: ModalDataType;
+	data: ServiceDataType<ExpenseTracker, { transaction_date: Date }>;
+	onClose: () => void;
+}
+
+const EditPaymentModal = ({ id, type, data, onClose }: EditPaymentModalProps) => {
+	const queryClient = useQueryClient();
+	const {
+		register,
+		formState: { errors },
+		setFocus,
+		handleSubmit,
+	} = useForm<EditPaymentFormSchema>({
+		resolver: zodResolver(editPaymentFormSchema),
+		defaultValues: {
+			place: data?.place,
+		},
+	});
+
+	const navigate = useNavigate();
+	const { startTransition, Loading, isLoading } = useLoading();
+	const { addToast } = useToastStore();
+
+	useEffect(() => {
+		setFocus('place');
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const onSubmit = async (formData: EditPaymentFormSchema) => {
+		try {
+			if (data?.id) {
+				await startTransition(editPaymentPlace({ id: data?.id, place: formData?.place }));
+			}
+
+			onClose();
+			addToast(toastData.EXPENSE_TRACKER.EDIT.SUCCESS);
+			navigate(routes.EXPENSE_TRACKER_BY_MONTH, { replace: true });
+		} catch (e) {
+			console.error(e);
+			addToast(toastData.EXPENSE_TRACKER.EDIT.ERROR);
+		} finally {
+			if (data?.transaction_date) {
+				queryClient.invalidateQueries({ queryKey: [...queryKey.EXPENSE_TRACKER, formatByKoreanTime(data?.transaction_date)] });
+			}
+		}
+	};
+
+	return (
+		<ModalLayout id={id} type={type} title={`Edit Payment`} onClose={onClose}>
+			<Form onSubmit={handleSubmit(onSubmit)}>
+				<LabelInput label="nickname" errorMessage={errors['place']?.message}>
+					<LabelInput.TextField type="text" id="place" {...register('place')} placeholder="Place" />
+				</LabelInput>
+				<SubmitButton type="submit">{isLoading ? Loading : 'Update'}</SubmitButton>
+			</Form>
+		</ModalLayout>
+	);
+};
+
+const Form = styled.form`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	gap: 16px;
+	margin-top: 16px;
+
+	@media screen and (max-width: 480px) {
+		min-height: calc(100dvh * 0.25);
+	}
+`;
+
+const SubmitButton = styled(Button)`
+	margin-top: 16px;
+	padding: var(--padding-container-mobile);
+	width: 100%;
+	color: var(--white);
+	background-color: var(--black);
+	font-size: var(--fz-p);
+	font-weight: var(--fw-semibold);
+
+	&:active,
+	&:focus {
+		background-color: var(--greyOpacity900);
+	}
+
+	&:disabled {
+		background-color: var(--greyOpacity400);
+	}
+`;
+
+export default EditPaymentModal;

--- a/src/components/modal/expenseTracker/index.ts
+++ b/src/components/modal/expenseTracker/index.ts
@@ -1,3 +1,4 @@
 export * from './schema';
 
 export { default as AddPaymentModal } from './AddPaymentModal';
+export { default as EditPaymentModal } from './EditPaymentModal';

--- a/src/components/modal/expenseTracker/schema.ts
+++ b/src/components/modal/expenseTracker/schema.ts
@@ -3,6 +3,7 @@ import { cardType, installmentPlanMonths, InstallmentType, paymentData } from '.
 import { today } from '../../../utils';
 
 type AddPaymentFormSchema = z.infer<typeof addPaymentFormSchema>;
+type EditPaymentFormSchema = z.infer<typeof editPaymentFormSchema>;
 
 const paymentMethodSchema = z.enum(paymentData.paymentMethod, {
 	errorMap: () => {
@@ -38,7 +39,7 @@ const priceUnitSchema = z.enum(paymentData.priceUnits, {
 const addPaymentFormSchema = z.object({
 	place: z
 		.string({ required_error: 'The Place where you spend money is in need' })
-		.min(1, { message: 'Write the place where you spend money ' }),
+		.min(1, { message: 'Write the place where you spend money' }),
 	usage_date: z
 		.date({
 			required_error: 'Select Date in essential',
@@ -57,5 +58,11 @@ const addPaymentFormSchema = z.object({
 		.refine(val => !isNaN(val) && val >= 0, 'Price should be over 0'),
 });
 
-export type { AddPaymentFormSchema };
-export { addPaymentFormSchema };
+const editPaymentFormSchema = z.object({
+	place: z
+		.string({ required_error: 'The Place where you spend money is in need' })
+		.min(1, { message: 'Write the place where you spend money' }),
+});
+
+export type { AddPaymentFormSchema, EditPaymentFormSchema };
+export { addPaymentFormSchema, editPaymentFormSchema };

--- a/src/components/modal/filmRecipe/AddFilmRecipeModal.tsx
+++ b/src/components/modal/filmRecipe/AddFilmRecipeModal.tsx
@@ -1,13 +1,11 @@
 import { FormEventHandler, useState } from 'react';
 import styled from '@emotion/styled';
-import { Session } from '@supabase/supabase-js';
-import { useQueryClient } from '@tanstack/react-query';
 import { type ModalDataType } from '..';
 import { FilmRecipeImageUpload, LoadingSpinner, CustomSelect, TextInput, ModalLayout, Button } from '../..';
 import { type RestrictedRecipeForValidation } from '../../../supabase/schema';
-import { useFilmRecipeImage, useAddFilmRecipeMutation } from '../../../hooks';
+import { useFilmRecipeImage, useAddFilmRecipeMutation, useClientSession } from '../../../hooks';
 import { useToastStore } from '../../../store';
-import { FILM_RECIPE_FORM, queryKey, toastData } from '../../../constants';
+import { FILM_RECIPE_FORM, toastData } from '../../../constants';
 
 interface AddFilmRecipeModalProps {
 	id: string;
@@ -49,8 +47,7 @@ const initialValidationState: { [key: string]: boolean } = {
 };
 
 const AddFilmRecipeModal = ({ id, type, onClose }: AddFilmRecipeModalProps) => {
-	const queryClient = useQueryClient();
-	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+	const { session } = useClientSession();
 
 	const [currentFilmFeature, setCurrentFilmFeature] = useState<Omit<RestrictedRecipeForValidation, 'imgSrc'>>(initialFilmFieldValue);
 	const [isTriggered, setTriggered] = useState(initialValidationState);

--- a/src/components/modal/modalType.ts
+++ b/src/components/modal/modalType.ts
@@ -9,13 +9,14 @@ import {
 	UpdateProfileModal,
 	TodoItemEditModal,
 	RecordModal,
+	EditPaymentModal,
 } from '.';
 
 type ModalDataType = (typeof modalType)[keyof typeof modalType];
 type BaseModalAction = 'GENERAL' | 'ADD' | 'READ' | 'EDIT' | 'REMOVE' | 'RESET_PASSWORD' | 'PROFILE'; // TODO: string & NonNullable<unknown>
 
 type ModalActionMap = {
-	[modalType.EXPENSE_TRACKER]: 'ADD';
+	[modalType.EXPENSE_TRACKER]: 'ADD' | 'EDIT';
 	[modalType.FILM_RECIPE]: 'READ' | 'ADD' | 'REMOVE';
 	[modalType.DIARY]: 'EDIT';
 	[modalType.USER]: 'RESET_PASSWORD' | 'PROFILE';
@@ -49,6 +50,10 @@ const MODAL_CONFIG: ModalConfig = {
 		ADD: {
 			type: modalType.EXPENSE_TRACKER,
 			Component: AddPaymentModal,
+		},
+		EDIT: {
+			type: modalType.EXPENSE_TRACKER,
+			Component: EditPaymentModal,
 		},
 	},
 	FILM_RECIPE: {

--- a/src/components/modal/modalType.ts
+++ b/src/components/modal/modalType.ts
@@ -12,16 +12,26 @@ import {
 } from '.';
 
 type ModalDataType = (typeof modalType)[keyof typeof modalType];
-type ModalAction = 'ADD' | 'READ' | 'EDIT' | 'REMOVE' | 'RESET_PASSWORD' | 'PROFILE' | string; // TODO: string & NonNullable<unknown>
+type BaseModalAction = 'GENERAL' | 'ADD' | 'READ' | 'EDIT' | 'REMOVE' | 'RESET_PASSWORD' | 'PROFILE'; // TODO: string & NonNullable<unknown>
+
+type ModalActionMap = {
+	[modalType.EXPENSE_TRACKER]: 'ADD';
+	[modalType.FILM_RECIPE]: 'READ' | 'ADD' | 'REMOVE';
+	[modalType.DIARY]: 'EDIT';
+	[modalType.USER]: 'RESET_PASSWORD' | 'PROFILE';
+	[modalType.TODO_REMINDER]: 'EDIT';
+	[modalType.COMMUTE_RECORDS]: 'ADD' | 'EDIT';
+};
 
 type ModalConfigItem = {
 	type: ModalDataType;
 	Component: ElementType;
+	action?: Lowercase<BaseModalAction>;
 };
 
 type ModalConfig = {
-	[DATA_TYPE in Uppercase<ModalDataType>]: {
-		[ACTION in ModalAction]: ModalConfigItem;
+	[DATA_TYPE in keyof typeof modalType]: {
+		[ACTION in ModalActionMap[(typeof modalType)[DATA_TYPE]]]: ModalConfigItem;
 	};
 };
 
@@ -81,13 +91,15 @@ const MODAL_CONFIG: ModalConfig = {
 		ADD: {
 			type: modalType.COMMUTE_RECORDS,
 			Component: RecordModal,
+			action: 'add',
 		},
 		EDIT: {
 			type: modalType.COMMUTE_RECORDS,
 			Component: RecordModal,
+			action: 'edit',
 		},
 	},
 };
 
-export type { ModalDataType };
-export { MODAL_CONFIG };
+export type { ModalDataType, BaseModalAction, ModalActionMap };
+export { MODAL_CONFIG, modalType };

--- a/src/components/modal/user/UpdateProfileModal.tsx
+++ b/src/components/modal/user/UpdateProfileModal.tsx
@@ -74,7 +74,7 @@ const UpdateProfileModal = ({ id, type, onClose, data }: UpdateProfileModalProps
 	};
 
 	return (
-		<ModalLayout id={id} type={type} title="Update Profile" onClose={onClose}>
+		<ModalLayout id={id} type={type} title={'Update Profile'} onClose={onClose}>
 			<Form onSubmit={handleSubmit(onSubmit)}>
 				<LabelInput label="nickname" errorMessage={errors['nickname']?.message}>
 					<LabelInput.TextField type="text" id="nickname" {...register('nickname')} placeholder="Nickname" />

--- a/src/components/todoReminder/QuickMemoDrawer.tsx
+++ b/src/components/todoReminder/QuickMemoDrawer.tsx
@@ -2,18 +2,15 @@ import styled from '@emotion/styled';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
-import { Session } from '@supabase/supabase-js';
 import { quickMemoDrawerSchema, QuickMemoDrawerSchema } from '.';
 import { Button, Drawer, TextInput } from '..';
 import { useDrawerStore, useToastStore } from '../../store';
-import { useLoading } from '../../hooks';
+import { useClientSession, useLoading } from '../../hooks';
 import { addTodo } from '../../supabase';
 import { toastData, routes, queryKey } from '../../constants';
 
 const QuickMemoDrawer = () => {
-	const queryClient = useQueryClient();
-	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+	const { queryClient, session } = useClientSession();
 
 	const { register, setValue, handleSubmit } = useForm<QuickMemoDrawerSchema>({
 		resolver: zodResolver(quickMemoDrawerSchema),

--- a/src/constants/commuteRecords.ts
+++ b/src/constants/commuteRecords.ts
@@ -1,6 +1,14 @@
-type StatusOption = (typeof status)[number];
+type StatusOption = (typeof COMMUTE_STATUS)[keyof typeof COMMUTE_STATUS];
 
-const status = ['present', 'absent', 'remote', 'half_day'] as const;
+const COMMUTE_STATUS = {
+	PRESENT: 'present',
+	ABSENT: 'absent',
+	REMOTE: 'remote',
+	HALF_DAY: 'half_day',
+} as const;
+
+// because of schema, z.enum can't refer the type of arr (e.g. Object.values(COMMUTE_STATUS))
+const commuteStatusList = [COMMUTE_STATUS.PRESENT, COMMUTE_STATUS.ABSENT, COMMUTE_STATUS.REMOTE, COMMUTE_STATUS.HALF_DAY] as const;
 
 export type { StatusOption };
-export { status };
+export { COMMUTE_STATUS, commuteStatusList };

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -88,6 +88,10 @@ const toastData = {
 			SUCCESS: { status: 'success', message: `Add payment ${FIXED_SUCCESS_PHRASE}` },
 			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} adding` },
 		},
+		EDIT: {
+			SUCCESS: { status: 'success', message: `Edit payment ${FIXED_SUCCESS_PHRASE}` },
+			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} editing` },
+		},
 		TOGGLE: {
 			SUCCESS: { status: 'success', message: `Set next month upcoming cost ${FIXED_SUCCESS_PHRASE}` },
 			ERROR: {

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -171,6 +171,10 @@ const toastData = {
 			SUCCESS: { status: 'success', message: `Check commute ${FIXED_SUCCESS_PHRASE}` },
 			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} checking ` },
 		},
+		EDIT: {
+			SUCCESS: { status: 'success', message: `Update commute ${FIXED_SUCCESS_PHRASE}` },
+			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} updating ` },
+		},
 	},
 } as const;
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from './mutations';
 
 export { default as useAuthQuery } from './useAuthQuery';
 export { default as useClickOutside } from './useClickOutside';
+export { default as useClientSession } from './useClientSession';
 export { default as useDrag } from './useDrag';
 export { default as useFilmRecipeImage } from './useFilmRecipeImage';
 export { default as useFunnel } from './useFunnel';

--- a/src/hooks/useClientSession.ts
+++ b/src/hooks/useClientSession.ts
@@ -1,0 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Session } from '@supabase/supabase-js';
+import { queryKey } from '../constants';
+
+const useClientSession = () => {
+	const queryClient = useQueryClient();
+	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+
+	return { queryClient, session };
+};
+
+export default useClientSession;

--- a/src/pages/ExpenseTrackerByMonthItem.tsx
+++ b/src/pages/ExpenseTrackerByMonthItem.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { FaWonSign } from 'react-icons/fa6';
 import { BsFillCreditCardFill } from 'react-icons/bs';
-import { Button, Switch } from '../components';
+import { Button, PaymentItemDetail, Switch } from '../components';
 import { useLoading, useTogglePaymentIsFixedMutation } from '../hooks';
 import { ExpenseTracker, removePayment } from '../supabase';
 import { monetizeWithSeparator, formatByKoreanTime } from '../utils';
@@ -55,10 +55,7 @@ const ExpenseTrackerByMonthItemPage = () => {
 			</div>
 
 			<Detail>
-				<DetailGroup>
-					<dt>Place</dt>
-					<dd>{payment.place}</dd>
-				</DetailGroup>
+				<PaymentItemDetail title={'Place'} description={payment.place} data={{ ...payment, transaction_date: currentDate }} />
 				<DetailGroup>
 					<dt>Bank</dt>
 					<dd>{payment.bank} bank</dd>
@@ -142,7 +139,7 @@ const DetailGroup = styled.div`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding: 8px 0;
+	padding: 16px;
 
 	dt {
 		font-weight: var(--fw-medium);

--- a/src/pages/TodoReminder.tsx
+++ b/src/pages/TodoReminder.tsx
@@ -1,11 +1,9 @@
 import { FormEvent, Suspense, useState } from 'react';
 import styled from '@emotion/styled';
-import { useQueryClient } from '@tanstack/react-query';
-import { Session } from '@supabase/supabase-js';
 import { BsPlus } from 'react-icons/bs';
 import { Button, SegmentedControl, ShrinkMotionBlock, TextInput, TodoList, TodoListLoader } from '../components';
 import { addTodo } from '../supabase';
-import { useLoading } from '../hooks';
+import { useClientSession, useLoading } from '../hooks';
 import { useToastStore } from '../store';
 import { queryKey, toastData } from '../constants';
 
@@ -13,8 +11,7 @@ export type ControlOption = (typeof segmentedControlOptions)[number];
 const segmentedControlOptions = ['All', 'Checked', 'Unchecked'] as const;
 
 const TodoReminderPage = () => {
-	const queryClient = useQueryClient();
-	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+	const { queryClient, session } = useClientSession();
 
 	const [value, setValue] = useState('');
 	const [controlOption, setControlOption] = useState<ControlOption>(segmentedControlOptions[0]);

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -1,18 +1,15 @@
 import styled from '@emotion/styled';
-import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { Controller, useForm } from 'react-hook-form';
-import { Session } from '@supabase/supabase-js';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, TagsInput, TextArea, TextInput, WriteSchema, writeSchema } from '../components';
 import { addDiary } from '../supabase';
-import { useLoading } from '../hooks';
+import { useClientSession, useLoading } from '../hooks';
 import { useToastStore } from '../store';
 import { queryKey, routes, toastData } from '../constants';
 
 const WritePage = () => {
-	const queryClient = useQueryClient();
-	const session = queryClient.getQueryData(queryKey.AUTH) as Session;
+	const { queryClient, session } = useClientSession();
 	const navigate = useNavigate();
 
 	const {

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -1,25 +1,25 @@
 import { ElementType } from 'react';
 import { UseQueryResult } from '@tanstack/react-query';
 import { create } from 'zustand';
-import { ServiceDataType } from '../supabase';
+import { ServiceDataType, TableRowData } from '../supabase';
 import { BaseModalAction, ModalDataType } from '../components';
 
 export type QueryRefetch = (options?: { throwOnError: boolean; cancelRefetch: boolean }) => Promise<UseQueryResult>;
 
-interface Modal {
+interface Modal<T = TableRowData, D = Record<string, never>> {
 	Component: ElementType;
 	props?: {
 		type: ModalDataType;
 		action?: BaseModalAction;
-		data: ServiceDataType;
+		data: ServiceDataType<T, D>;
 		refetch?: QueryRefetch;
 		onTopLevelModalClose?: () => void;
 	};
 }
 
 interface ModalState {
-	modals: Modal[];
-	setModal: (data: Modal) => void;
+	modals: Modal<unknown, unknown>[];
+	setModal: <T = TableRowData, D = Record<string, never>>(data: Modal<T, D>) => void;
 	removeModal: (Component: ElementType) => void;
 	resetModals: () => void;
 }

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -2,7 +2,7 @@ import { ElementType } from 'react';
 import { UseQueryResult } from '@tanstack/react-query';
 import { create } from 'zustand';
 import { ServiceDataType } from '../supabase';
-import { ModalDataType } from '../components';
+import { BaseModalAction, ModalDataType } from '../components';
 
 export type QueryRefetch = (options?: { throwOnError: boolean; cancelRefetch: boolean }) => Promise<UseQueryResult>;
 
@@ -10,6 +10,7 @@ interface Modal {
 	Component: ElementType;
 	props?: {
 		type: ModalDataType;
+		action?: BaseModalAction;
 		data: ServiceDataType;
 		refetch?: QueryRefetch;
 		onTopLevelModalClose?: () => void;

--- a/src/supabase/api/expenseTracker.ts
+++ b/src/supabase/api/expenseTracker.ts
@@ -210,6 +210,14 @@ const togglePaymentIsFixed = async ({ id, isFixed, updated_at }: { id: string; i
 	}
 };
 
+const editPaymentPlace = async ({ id, place }: { id: string; place: string }) => {
+	const { error } = await supabase.from(TABLE).update({ place }).eq('id', id);
+
+	if (error) {
+		throw new Error(error.message);
+	}
+};
+
 const removePayment = async ({ id }: { id: string }) => {
 	await supabase.from(TABLE).delete().eq('id', id);
 };
@@ -224,6 +232,7 @@ export {
 	getFixedCostPaymentsByMonth,
 	getCreditCardPaymentsByMonth,
 	addPayment,
+	editPaymentPlace,
 	togglePaymentIsFixed,
 	removePayment,
 };

--- a/src/supabase/schema.ts
+++ b/src/supabase/schema.ts
@@ -2,7 +2,8 @@ import { Database } from './database.types';
 
 type TableRowData = Diary | Recipe | Todo | ExpenseTracker | User | CommuteRecord;
 
-type ServiceDataType<T = TableRowData> = T | Partial<T> | null;
+// {} => Record<string, never>, based on eslint ban-types
+type ServiceDataType<T = TableRowData, D = Record<string, never>> = (T & D) | Partial<T & D> | null;
 
 type Diary = Database['public']['Tables']['diary']['Row'];
 type Recipe = Database['public']['Tables']['recipes']['Row'];
@@ -25,6 +26,7 @@ interface RestricedRecipeWithImage extends RestrictedRecipe {
 type RestrictedRecipeForValidation = Omit<RestrictedRecipe, 'id' | 'user_id' | 'created_at' | 'updated_at'>;
 
 export type {
+	TableRowData,
 	ServiceDataType,
 	Diary,
 	Recipe,


### PR DESCRIPTION
- develop `useClientSession` hook
  - to remove two lines of `import` statement on every components 

- develop editing `CommuteRecords` table data
  - add `action` property on `Modal` props to handle conditional `RecordModal`
  - add new Toast info related to `Commute_Records`

- use curly brace for passing prop on `ModalLayout`
- develop `EditPaymentModal` and `editPaymentPlace`
  - change `ServiceDataType` to react with additional field on `TableRowData`
  - change interface `Modal` following changing of `ServiceDataType` 