### PR TITLE
feat : add `holiday` type of `COMMUTE_STATUS ` on `CommuteRecords` page

### DIFF
--- a/src/components/common/CustomSelect.tsx
+++ b/src/components/common/CustomSelect.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from 'react';
 import styled from '@emotion/styled';
 import { FieldError } from 'react-hook-form';
 import { BiSolidChevronRight } from 'react-icons/bi';
-import { Button } from '.';
+import { Button, Symbol } from '.';
 import type { ExpenseTracker, RestrictedRecipeForValidation } from '../../supabase';
 import { useClickOutside } from '../../hooks';
 import { customPropReceiver, PaymentDataValueType, FilmRecipeFieldDataType } from '../../constants';
@@ -49,7 +49,11 @@ const CustomSelect = <T extends CustomSelectDataType>({
 				</SelectValue>
 				<Chevron size="21" color="var(--black)" $isOpen={isOpen} />
 			</SelectTrigger>
-			{error && <ErrorMessage>﹡ {error?.message}</ErrorMessage>}
+			{error && (
+				<ErrorMessage>
+					<Symbol>﹡</Symbol> {error?.message}
+				</ErrorMessage>
+			)}
 
 			<SelectContent isOpen={isOpen} aria-labelledby={`custom-select-${generatedId}-content`}>
 				<Label>{label.toUpperCase()}</Label>

--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -4,7 +4,7 @@ import { FieldError } from 'react-hook-form';
 import { DayPicker } from 'react-day-picker';
 import { IoMdCalendar } from 'react-icons/io';
 import { ko } from 'date-fns/locale';
-import { Button } from '..';
+import { Button, Symbol } from '..';
 import { useClickOutside } from '../../hooks';
 import { customPropReceiver } from '../../constants';
 import { formatByKoreanTime } from '../../utils';
@@ -30,7 +30,11 @@ const DatePicker = ({ selected, setSelected, error, disabled, isFloated = false,
 				</IconBackground>
 				<span>{selected ? formatByKoreanTime(selected) : 'Select Date'}</span>
 			</TriggerButton>
-			{error && <ErrorMessage>﹡ {error?.message}</ErrorMessage>}
+			{error && (
+				<ErrorMessage>
+					<Symbol>﹡</Symbol> {error?.message}
+				</ErrorMessage>
+			)}
 			<DayPickerWrapper isFloated={isFloated}>
 				{isOpen && (
 					<DayPicker

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from 'react';
 import styled from '@emotion/styled';
 import { BiSolidChevronRight } from 'react-icons/bi';
 import { FieldError } from 'react-hook-form';
-import { Button } from '..';
+import { Button, Symbol } from '..';
 import { customPropReceiver } from '../../constants';
 import { useClickOutside } from '../../hooks';
 
@@ -34,7 +34,11 @@ const Select = <T extends string>({ data: options, placeholder, descriptionLabel
 				<span>{currentValue ?? placeholder}</span>
 				<Chevron size="19" color="var(--black)" $isOpen={isOpen} />
 			</SelectTrigger>
-			{error && <ErrorMessage>﹡ {error?.message}</ErrorMessage>}
+			{error && (
+				<ErrorMessage>
+					<Symbol>﹡</Symbol> {error?.message}
+				</ErrorMessage>
+			)}
 			<SelectContent isOpen={isOpen} aria-labelledby={`select-${generatedId}-content`}>
 				{descriptionLabel && <SelectDescriptionLabel>{descriptionLabel}</SelectDescriptionLabel>}
 				<SelectItemList>

--- a/src/components/common/Symbol.tsx
+++ b/src/components/common/Symbol.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+interface SymbolProps {
+	children: ReactNode;
+}
+
+const Symbol = ({ children }: SymbolProps) => {
+	return (
+		<span
+			css={{
+				fontSize: '1.2em',
+			}}>
+			{children}
+		</span>
+	);
+};
+
+export default Symbol;

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, Children, cloneElement, ForwardedRef, forwardRef, HTMLAttributes, ReactElement, useId, useRef } from 'react';
 import styled from '@emotion/styled';
+import { Symbol } from '.';
 
 interface TextAreaProps {
 	children: ReactElement;
@@ -16,7 +17,11 @@ const TextArea = ({ children, errorMessage, ...props }: TextAreaProps) => {
 	return (
 		<Container {...props}>
 			{cloneElement(child, { id, ref, ...child.props })}
-			{errorMessage && <Message>﹡ {errorMessage}</Message>}
+			{errorMessage && (
+				<Message>
+					<Symbol>﹡</Symbol> {errorMessage}
+				</Message>
+			)}
 		</Container>
 	);
 };

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, Children, cloneElement, FocusEvent, ForwardedRef, forwardRef, HTMLAttributes, ReactElement, useId } from 'react';
 import styled from '@emotion/styled';
+import { Symbol } from '.';
 
 interface TextInputProps extends Omit<HTMLAttributes<HTMLInputElement>, 'size'> {
 	children: ReactElement;
@@ -19,7 +20,11 @@ const TextInput = ({ children, label, errorMessage, ...props }: TextInputProps) 
 				id,
 				...child.props,
 			})}
-			{errorMessage && <Message>﹡ {errorMessage}</Message>}
+			{errorMessage && (
+				<Message>
+					<Symbol>﹡</Symbol> {errorMessage}
+				</Message>
+			)}
 		</Container>
 	);
 };

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,15 +1,17 @@
 import styled from '@emotion/styled';
+import { RiCloseFill } from 'react-icons/ri';
 import { motion } from 'framer-motion';
-import { useToastStore } from '../../store';
+import { Flex, Button } from '.';
+import { status, useToastStore } from '../../store';
 import { useToastUnsubscribe } from '../../hooks';
 
 const Toast = () => {
-	const { toast } = useToastStore();
+	const { toast, removeToast } = useToastStore();
 
 	useToastUnsubscribe();
 
 	return (
-		<MotionWrapper
+		<MotionBlock
 			isToastNull={toast === null}
 			initial={{ y: '100%', opacity: 0 }}
 			animate={{ y: 0, opacity: 1 }}
@@ -17,24 +19,33 @@ const Toast = () => {
 			exit={{ y: '100%', opacity: 0 }}
 			transition={{ duration: 0.4, delay: 0.2, ease: 'easeOut' }}>
 			<Container>
-				<Status status={toast?.status ?? 'info'} />
-				<Message>{toast?.message}</Message>
+				<Flex gap={'16px'}>
+					<Status status={toast?.status ?? status['INFO']} />
+					<Message>{toast?.message}</Message>
+				</Flex>
+				<RemoveToastButton type="button" onClick={removeToast}>
+					<RiCloseFill size="21" color="var(--white)" />
+				</RemoveToastButton>
 			</Container>
-		</MotionWrapper>
+		</MotionBlock>
 	);
 };
 
-const MotionWrapper = styled(motion.div)<{ isToastNull: boolean }>`
+const MotionBlock = styled(motion.div)<{ isToastNull: boolean }>`
 	position: fixed;
 	display: ${({ isToastNull }) => (isToastNull ? 'none' : 'block')};
 	right: var(--padding-container-mobile);
 	bottom: calc(var(--nav-height) + 3 * var(--padding-container-mobile));
 	z-index: var(--toast-index);
+
+	@media screen and (min-width: 480px) {
+		right: calc(100dvw / 2 - (var(--max-app-width) / 2) + 16px);
+	}
 `;
 
 const Container = styled.div`
 	display: flex;
-	justify-content: center;
+	justify-content: space-between;
 	align-items: center;
 	gap: 8px;
 	padding: calc(var(--padding-container-mobile) * 0.6) var(--padding-container-mobile);
@@ -46,7 +57,7 @@ const Container = styled.div`
 
 	@media screen and (min-width: 640px) {
 		max-width: var(--max-app-width);
-		min-width: calc(var(--min-app-width) - 2 * var(--padding-container-mobile));
+		min-width: calc(var(--max-app-width) - 2 * var(--padding-container-mobile));
 	}
 `;
 
@@ -71,6 +82,14 @@ const Message = styled.p`
 	font-size: var(--fz-sm);
 	font-weight: var(--fw-semibold);
 	color: var(--grey800);
+`;
+
+const RemoveToastButton = styled(Button)`
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	padding: calc(var(--padding-container-mobile) * 0.15);
+	background-color: var(--black);
 `;
 
 export default Toast;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -6,6 +6,7 @@ export { default as DatePicker } from './DatePicker';
 export { default as Description } from './Description';
 export { default as Drawer } from './Drawer';
 export { default as EmptyMessage } from './EmptyMessage';
+export { default as Flex } from './Flex';
 export { default as LazyImage } from './LazyImage';
 export { default as Logo } from './Logo';
 export { default as SegmentedControl } from './SegmentedControl';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -13,6 +13,7 @@ export { default as Select } from './Select';
 export { default as ShrinkMotionBlock } from './ShrinkMotionBlock';
 export { default as SkeletonLoader } from './SkeletonLoader';
 export { default as Switch } from './Switch';
+export { default as Symbol } from './Symbol';
 export { default as TagsInput } from './TagsInput';
 export { default as TextArea } from './TextArea';
 export { default as TextInput } from './TextInput';

--- a/src/components/commuteRecords/Records.tsx
+++ b/src/components/commuteRecords/Records.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { MODAL_CONFIG, ModalActionMap, modalType } from '../modal';
-import { queryKey, StatusOption } from '../../constants';
+import { COMMUTE_STATUS, queryKey, StatusOption } from '../../constants';
 import { CommuteRecord, getMonthlyRecords } from '../../supabase';
 import { calendar, formatByKoreanTime, getMonthIndexFromMonths, Month } from '../../utils';
 import { useModalStore } from '../../store';
 import { useClientSession } from '../../hooks';
+import { Fragment } from 'react';
 
 interface RecordsProps {
 	yearAndMonth: {
@@ -54,38 +55,52 @@ const Records = ({ yearAndMonth: { year, month } }: RecordsProps) => {
 	};
 
 	return (
-		<Container>
-			{calendar[monthIndex].map(day => {
-				const workedDay = data.find(item => new Date(item.date).getDate() === day);
+		<Fragment>
+			<Calendar>
+				{calendar[monthIndex].map(day => {
+					const workedDay = data.find(item => new Date(item.date).getDate() === day);
 
-				return (
-					<Day
-						key={day}
-						status={workedDay?.status}
-						tabIndex={0}
-						onClick={() => handleRecordModal({ type: !workedDay ? 'ADD' : 'EDIT', day, commuteData: workedDay })}>
-						<Label>{day}</Label>
-						<Emoji>
-							{workedDay?.status === 'present' || workedDay?.status === 'remote'
-								? '✅'
-								: workedDay?.status === 'half_day'
-								? '🥝'
-								: workedDay?.status === 'absent'
-								? '💤'
-								: '🫥'}
-						</Emoji>
-					</Day>
-				);
-			})}
-		</Container>
+					return (
+						<Day
+							key={day}
+							status={workedDay?.status ?? COMMUTE_STATUS.HOLIDAY}
+							tabIndex={0}
+							onClick={() => handleRecordModal({ type: !workedDay ? 'ADD' : 'EDIT', day, commuteData: workedDay })}>
+							<Label>{day}</Label>
+							<Emoji>
+								{workedDay?.status === 'present'
+									? '🏢'
+									: workedDay?.status === 'remote'
+									? '💼'
+									: workedDay?.status === 'half_day'
+									? '🥝'
+									: workedDay?.status === 'absent'
+									? '💤'
+									: '🏝️'}
+							</Emoji>
+						</Day>
+					);
+				})}
+			</Calendar>
+			<Overview>
+				<li>
+					<span>Full-Time</span>
+					<p>{data.filter(day => day.status === 'present').length}</p>
+				</li>
+				<li>
+					<span>Remote</span>
+					<p>{data.filter(day => day.status === 'remote').length}</p>
+				</li>
+			</Overview>
+		</Fragment>
 	);
 };
 
-const Container = styled.ul`
+const Calendar = styled.ul`
 	display: grid;
 	grid-template-columns: repeat(5, 1fr);
 	gap: 8px;
-	margin: 32px auto;
+	margin: 32px auto 16px;
 `;
 
 const Day = styled.li<{ status: StatusOption }>`
@@ -126,6 +141,33 @@ const Label = styled.span`
 
 const Emoji = styled.span`
 	font-size: var(--fz-h4);
+`;
+
+const Overview = styled.ul`
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 16px;
+
+	li {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--padding-container-mobile);
+		background-color: var(--grey50);
+		border-radius: var(--radius-s);
+
+		span {
+			color: var(--grey800);
+			font-weight: var(--fw-semibold);
+		}
+
+		p {
+			color: var(--blue200);
+			font-size: var(--fz-h7);
+			font-weight: var(--fw-semibold);
+		}
+	}
 `;
 
 export default Records;

--- a/src/components/commuteRecords/StatusSelect.tsx
+++ b/src/components/commuteRecords/StatusSelect.tsx
@@ -20,7 +20,11 @@ const StatusSelect = <T extends string>({ data, currentValue, error, onSelect }:
 					</Option>
 				))}
 			</Options>
-			{error && <ErrorMessage>﹡ {error?.message}</ErrorMessage>}
+			{error && (
+				<ErrorMessage>
+					<Symbol>﹡</Symbol> {error?.message}
+				</ErrorMessage>
+			)}
 		</Container>
 	);
 };
@@ -71,6 +75,10 @@ const ErrorMessage = styled.p`
 	padding-left: 4px;
 	font-size: var(--fz-sm);
 	color: var(--red200);
+`;
+
+const Symbol = styled.span`
+	font-size: 1.2em;
 `;
 
 export default StatusSelect;

--- a/src/components/commuteRecords/loader/RecordsLoader.tsx
+++ b/src/components/commuteRecords/loader/RecordsLoader.tsx
@@ -2,17 +2,29 @@ import { SkeletonLoader } from '../../common';
 
 const RecordsLoader = () => {
 	return (
-		<div
-			css={{
-				display: 'grid',
-				gridTemplateColumns: 'repeat(5, 1fr)',
-				gap: '8px',
-				margin: '32px auto',
-			}}>
-			{Array.from({ length: 30 }, (_, idx) => (
-				<SkeletonLoader key={idx} width={'100%'} height={'80px'} />
-			))}
-		</div>
+		<>
+			<div
+				css={{
+					display: 'grid',
+					gridTemplateColumns: 'repeat(5, 1fr)',
+					gap: '8px',
+					margin: '32px auto 16px',
+				}}>
+				{Array.from({ length: 30 }, (_, idx) => (
+					<SkeletonLoader key={idx} width={'100%'} height={'80px'} />
+				))}
+			</div>
+			<div
+				css={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '8px',
+					marginBottom: '16px',
+				}}>
+				<SkeletonLoader width={'100%'} height={'58px'} />
+				<SkeletonLoader width={'100%'} height={'58px'} />
+			</div>
+		</>
 	);
 };
 

--- a/src/constants/commuteRecords.ts
+++ b/src/constants/commuteRecords.ts
@@ -5,6 +5,7 @@ const COMMUTE_STATUS = {
 	ABSENT: 'absent',
 	REMOTE: 'remote',
 	HALF_DAY: 'half_day',
+	HOLIDAY: 'holiday',
 } as const;
 
 // because of schema, z.enum can't refer the type of arr (e.g. Object.values(COMMUTE_STATUS))

--- a/src/pages/CommuteRecords.tsx
+++ b/src/pages/CommuteRecords.tsx
@@ -3,26 +3,6 @@ import styled from '@emotion/styled';
 import { Records, RecordsLoader, Select, WorkInProgress } from '../components';
 import { currentMonth, currentYear, getMonthIndexFromMonths, months, years } from '../utils';
 
-/**
- *
- * commute_records
- * {
- * 	id : uuid
- * user_id: string;
- * date: string;
- * status: 'present' | 'absent' | 'remote' | 'half_day';
- * workplace: string;
- * notes: boolean;
- * created_at: string;
- * updated_at: string;
- * }
- */
-
-// TODO:
-// 0 - update UI design for Calendar
-// 1 - change Emoji with SVG
-// 2 - add trigger with mutation
-
 const CommuteRecordsPage = () => {
 	const [yearAndMonth, setYearAndMonth] = useState({
 		year: `${currentYear}`,
@@ -30,7 +10,7 @@ const CommuteRecordsPage = () => {
 	});
 
 	return (
-		<Container>
+		<section>
 			<Title id="commute-tracker-page-title">Commute Tracker</Title>
 			<Controller>
 				<Select
@@ -38,7 +18,13 @@ const CommuteRecordsPage = () => {
 					placeholder={'Select Year'}
 					descriptionLabel={'Year'}
 					currentValue={yearAndMonth.year}
-					onSelect={option => setYearAndMonth({ ...yearAndMonth, year: option })}
+					onSelect={option =>
+						setYearAndMonth({
+							...yearAndMonth,
+							year: option,
+							month: getMonthIndexFromMonths(yearAndMonth.month) >= currentMonth ? months[currentMonth] : yearAndMonth.month,
+						})
+					}
 				/>
 				<Select
 					data={+yearAndMonth.year === currentYear ? months.filter((_, idx) => idx <= currentMonth) : [...months].reverse()}
@@ -53,11 +39,9 @@ const CommuteRecordsPage = () => {
 				<Records yearAndMonth={yearAndMonth} />
 			</Suspense>
 			<WorkInProgress />
-		</Container>
+		</section>
 	);
 };
-
-const Container = styled.section``;
 
 const Title = styled.h2`
 	font-size: var(--fz-h5);

--- a/src/pages/UpdatePassword.tsx
+++ b/src/pages/UpdatePassword.tsx
@@ -99,7 +99,9 @@ const UpdatePassword = () => {
 		<div css={pageCss.container}>
 			<form css={pageCss.form} onSubmit={handleSubmit(onSubmit)}>
 				<AuthLogo />
-				<Title>﹡ Update Password ﹡</Title>
+				<Title>
+					<Symbol>﹡</Symbol> Update Password <Symbol>﹡</Symbol>
+				</Title>
 
 				<EmailInfo>{searchParams.get('email') || state?.email}</EmailInfo>
 				<LabelInput label="Password" errorMessage={errors['password']?.message}>
@@ -125,6 +127,10 @@ const Title = styled.h4`
 	font-weight: var(--fw-semibold);
 	border-radius: var(--radius-s);
 	text-align: center;
+`;
+
+const Symbol = styled.span`
+	font-size: 1.2em;
 `;
 
 const EmailInfo = styled.div`

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,5 @@
+export * from './useToastStore';
+
 export { default as useDrawerStore } from './useDrawerStore';
 export { default as useModalStore } from './useModalStore';
 export { default as useUserStore } from './useUserStore';
-export { default as useToastStore } from './useToastStore';

--- a/src/store/useToastStore.ts
+++ b/src/store/useToastStore.ts
@@ -11,6 +11,13 @@ interface ToastState {
 	removeToast: () => void;
 }
 
+const status = {
+	SUCCESS: 'success',
+	WARN: 'warn',
+	INFO: 'info',
+	ERROR: 'error',
+} as const;
+
 const useToastStore = create<ToastState>(set => ({
 	toast: null,
 	addToast(newToast) {
@@ -22,4 +29,4 @@ const useToastStore = create<ToastState>(set => ({
 }));
 
 export type { Toast };
-export default useToastStore;
+export { status, useToastStore };

--- a/src/supabase/api/commuteRecords.ts
+++ b/src/supabase/api/commuteRecords.ts
@@ -3,7 +3,7 @@ import supabase from '../service';
 
 const TABLE = 'commute_records';
 
-const getMonthlyRecords = async ({ year, month, user_id }: { year: number; month: number; user_id: string }) => {
+const getMonthlyRecords = async ({ year, month, user_id }: { year: number; month: number; user_id: string }): Promise<CommuteRecord[]> => {
 	const startDate = `${year}-${`${month}`.padStart(2, '0')}-01`;
 	const endDate = `${year}-${`${month}`.padStart(2, '0')}-${new Date(year, month, 0).getDate()}`;
 


### PR DESCRIPTION
- develop `Symbol` component and apply on a few components
- add `Flex` component on index.ts strategy
- set the position of `Toast` on center of screen
  - Originally, `Toast` component was set on the middle of screen when it's on `mobile`
  - Set on on the middle of screen when it's on `Desktop` and `Tablet` as well
  - add `RemoveToastButton` to delete `Toast` directly
- add `holiday` type of `COMMUTE_STATUS`
  - change icons of `present`and`remote`
  - add new icon of `holiday` type
  - add UI of total counts based on full-time and remote status