### PR TITLE
feat : add `priceUnitType` state and use it to redefine data to be shown

### DIFF
--- a/src/components/expenseTracker/PaymentList.tsx
+++ b/src/components/expenseTracker/PaymentList.tsx
@@ -47,8 +47,8 @@ const PaymentList = ({ selectedDate, currentPaymentMethod, currentPriceUnit }: P
 				</TotalPriceHover>
 			)}
 
-			{totalPrice === 0 ? (
-				<EmptyMessage emoji={'💳'}>{`No ${currentPaymentMethod === 'All' ? '' : currentPaymentMethod} expenses recorded`}</EmptyMessage>
+			{totalPrice === 0 || filteredData.length === 0 ? (
+				<EmptyMessage emoji={'💳'}>{`No ${currentPaymentMethod === 'All' ? '' : currentPaymentMethod} Expenses Recorded`}</EmptyMessage>
 			) : (
 				<PaymentListContent>
 					{filteredData.map((payment, idx) => (

--- a/src/components/modal/modalType.ts
+++ b/src/components/modal/modalType.ts
@@ -12,6 +12,15 @@ import {
 	EditPaymentModal,
 } from '.';
 
+const modalType = {
+	EXPENSE_TRACKER: 'expense_tracker',
+	FILM_RECIPE: 'film_recipe',
+	DIARY: 'diary',
+	USER: 'user',
+	TODO_REMINDER: 'todo_reminder',
+	COMMUTE_RECORDS: 'commute_records',
+} as const;
+
 type ModalDataType = (typeof modalType)[keyof typeof modalType];
 type BaseModalAction = 'GENERAL' | 'ADD' | 'READ' | 'EDIT' | 'REMOVE' | 'RESET_PASSWORD' | 'PROFILE'; // TODO: string & NonNullable<unknown>
 
@@ -35,15 +44,6 @@ type ModalConfig = {
 		[ACTION in ModalActionMap[(typeof modalType)[DATA_TYPE]]]: ModalConfigItem;
 	};
 };
-
-const modalType = {
-	EXPENSE_TRACKER: 'expense_tracker',
-	FILM_RECIPE: 'film_recipe',
-	DIARY: 'diary',
-	USER: 'user',
-	TODO_REMINDER: 'todo_reminder',
-	COMMUTE_RECORDS: 'commute_records',
-} as const;
 
 const MODAL_CONFIG: ModalConfig = {
 	EXPENSE_TRACKER: {

--- a/src/components/modal/todoReminder/TodoItemEditModal.tsx
+++ b/src/components/modal/todoReminder/TodoItemEditModal.tsx
@@ -53,13 +53,12 @@ const TodoItemEditModal = ({ id: modalId, type, onClose, data: { id, content, ta
 
 	const onSubmit = async (formData: EditTodoItemFormSchema) => {
 		if (
-			reminder_time
-				? isEqual(
-						{ content: formData.content, reminder_time: formatByKoreanTime(formData.reminder_time) },
-						{ content, reminder_time: formatByKoreanTime(reminder_time) },
-						// eslint-disable-next-line no-mixed-spaces-and-tabs
-				  )
-				: false
+			reminder_time &&
+			isEqual(
+				{ content: formData.content, reminder_time: formatByKoreanTime(formData.reminder_time) },
+				{ content, reminder_time: formatByKoreanTime(reminder_time) },
+				// eslint-disable-next-line no-mixed-spaces-and-tabs
+			)
 		) {
 			addToast(toastData.TODO_REMINDER.EDIT.WARN);
 			return;

--- a/src/components/todoReminder/TodoItem.tsx
+++ b/src/components/todoReminder/TodoItem.tsx
@@ -74,6 +74,11 @@ const TodoItem = ({ id, todo, isContentEditing, isDragging, onEditingIdChange, o
 	};
 
 	const onSubmit = ({ content }: TodoItemSchema) => {
+		if (content === todo?.content) {
+			onEditingIdChange(false);
+			return;
+		}
+
 		editContent({ id: todo?.id, content, updated_at: new Date().toISOString() });
 	};
 
@@ -106,7 +111,7 @@ const TodoItem = ({ id, todo, isContentEditing, isDragging, onEditingIdChange, o
 							<>
 								{isContentEditing ? (
 									<ContentEditingForm onSubmit={handleSubmit(onSubmit)}>
-										<TextInput errorMessage={errors?.content?.message}>
+										<TextInput errorMessage={errors?.['content']?.message}>
 											<TextInput.TextField
 												id="todoItem_content"
 												{...register('content')}

--- a/src/constants/expenseTracker.ts
+++ b/src/constants/expenseTracker.ts
@@ -22,6 +22,11 @@ type PriceUnitSymbolType = PriceUnitGroup['unitSymbol'][number];
 
 type MatchedPriceUnitWithSymbol = Record<(typeof priceUnit.unitType)[number], (typeof priceUnit.unitSymbol)[number]>;
 
+const ZERO_PRICE = 0;
+
+const WON_AND_JPY_SEPARATOR = 1000;
+const USD_GBP_EUR_SEPARATOR = 1;
+
 const paymentMethod = {
 	CARD: 'Card',
 	CASH: 'Cash',
@@ -76,4 +81,15 @@ export type {
 	PriceUnitSymbolType,
 	MatchedPriceUnitWithSymbol,
 };
-export { paymentMethod, paymentData, installmentPlanMonths, cardType, priceUnit, bankSvgs, matchedPriceUnitWithSymbol };
+export {
+	ZERO_PRICE,
+	WON_AND_JPY_SEPARATOR,
+	USD_GBP_EUR_SEPARATOR,
+	paymentMethod,
+	paymentData,
+	installmentPlanMonths,
+	cardType,
+	priceUnit,
+	bankSvgs,
+	matchedPriceUnitWithSymbol,
+};

--- a/src/constants/expenseTracker.ts
+++ b/src/constants/expenseTracker.ts
@@ -22,8 +22,13 @@ type PriceUnitSymbolType = PriceUnitGroup['unitSymbol'][number];
 
 type MatchedPriceUnitWithSymbol = Record<(typeof priceUnit.unitType)[number], (typeof priceUnit.unitSymbol)[number]>;
 
+const paymentMethod = {
+	CARD: 'Card',
+	CASH: 'Cash',
+} as const;
+
 const paymentData = {
-	paymentMethod: ['Card', 'Cash'] as const,
+	paymentMethod: [paymentMethod.CARD, paymentMethod.CASH],
 	banks: ['신한', '하나', '국민', '우리', 'IBK기업', '농협', '카카오뱅크', '토스뱅크', '새마을', 'SC제일', '씨티', '해당없음'] as const,
 	priceUnits: ['WON', 'USD', 'GBP', 'EUR', 'JPY'],
 } as const;
@@ -31,9 +36,9 @@ const paymentData = {
 const installmentPlanMonths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 24, 36] as const;
 
 const cardType = {
-	신용: 'Credit',
-	체크: 'Debit',
-	미확인: 'Unconfirmed',
+	CREDIT: 'Credit',
+	DEBIT: 'Debit',
+	UNCONFIRMED: 'Unconfirmed',
 } as const;
 
 const priceUnit = {
@@ -71,4 +76,4 @@ export type {
 	PriceUnitSymbolType,
 	MatchedPriceUnitWithSymbol,
 };
-export { paymentData, installmentPlanMonths, cardType, priceUnit, bankSvgs, matchedPriceUnitWithSymbol };
+export { paymentMethod, paymentData, installmentPlanMonths, cardType, priceUnit, bankSvgs, matchedPriceUnitWithSymbol };

--- a/src/constants/staleTime.ts
+++ b/src/constants/staleTime.ts
@@ -10,7 +10,7 @@ const staleTime = {
 		BY_MONTH: ONE_SECOND * 5,
 	},
 	TODOS: {
-		PAGE_INFO: ONE_SECOND * 5,
+		PAGE_INFO: ONE_SECOND * 15,
 		ALL_WITH_PAGINATION: ONE_SECOND * 10,
 	},
 };

--- a/src/pages/CommuteRecords.tsx
+++ b/src/pages/CommuteRecords.tsx
@@ -27,7 +27,7 @@ const CommuteRecordsPage = () => {
 					}
 				/>
 				<Select
-					data={+yearAndMonth.year === currentYear ? months.filter((_, idx) => idx <= currentMonth) : [...months].reverse()}
+					data={+yearAndMonth.year === currentYear ? months.filter((_, idx) => idx <= currentMonth).reverse() : [...months].reverse()}
 					placeholder={'Select Month'}
 					descriptionLabel={'Month'}
 					currentValue={yearAndMonth.month}

--- a/src/pages/ExpenseTrackerReport.tsx
+++ b/src/pages/ExpenseTrackerReport.tsx
@@ -2,9 +2,11 @@ import { Suspense, useState } from 'react';
 import styled from '@emotion/styled';
 import { Description, ExpenseChart, ExpenseChartLoader, Select } from '../components';
 import { type Month, currentMonth, getMonthIndexFromMonths, months } from '../utils';
+import { priceUnit, PriceUnitType } from '../constants';
 
 const ExpenseTrackerReportPage = () => {
 	const [selectMonth, setSelectMonth] = useState<Month>(months[currentMonth]);
+	const [priceUnitType, setPriceUnitType] = useState<PriceUnitType>(priceUnit.unitType[0]); // WON
 
 	return (
 		<section>
@@ -12,14 +14,22 @@ const ExpenseTrackerReportPage = () => {
 				<span>Report of</span>
 				<Select
 					data={months.filter((_, idx) => idx <= currentMonth).reverse()}
-					placeholder={'month'}
+					placeholder={'Month'}
 					currentValue={selectMonth}
 					onSelect={option => setSelectMonth(months[getMonthIndexFromMonths(option)])}
 				/>
+				<Select
+					data={priceUnit.unitType}
+					placeholder={'Price Unit'}
+					currentValue={priceUnitType}
+					onSelect={option => setPriceUnitType(option)}
+				/>
 			</Title>
-			<Description>This chart will show price based on Korean WON(₩)</Description>
+			<Description>
+				This chart will show price based on <UnitType>{priceUnitType}</UnitType>
+			</Description>
 			<Suspense fallback={<ExpenseChartLoader />}>
-				<ExpenseChart selectMonth={selectMonth} />
+				<ExpenseChart selectMonth={selectMonth} priceUnitType={priceUnitType} />
 			</Suspense>
 		</section>
 	);
@@ -37,6 +47,15 @@ const Title = styled.h2`
 	span[aria-label='month'] {
 		color: var(--blue200);
 	}
+`;
+
+const UnitType = styled.span`
+	display: inline-block;
+	padding: calc(var(--padding-container-mobile) * 0.25);
+	border-radius: var(--radius-s);
+	font-weight: var(--fw-semibold);
+	color: var(--blue100);
+	background-color: var(--blue200);
 `;
 
 export default ExpenseTrackerReportPage;

--- a/src/pages/TodoReminder.tsx
+++ b/src/pages/TodoReminder.tsx
@@ -15,6 +15,7 @@ const TodoReminderPage = () => {
 
 	const [value, setValue] = useState('');
 	const [controlOption, setControlOption] = useState<ControlOption>(segmentedControlOptions[0]);
+
 	const { addToast } = useToastStore();
 	const { startTransition, Loading, isLoading } = useLoading();
 

--- a/src/supabase/api/expenseTracker.ts
+++ b/src/supabase/api/expenseTracker.ts
@@ -181,11 +181,7 @@ const getFixedCostPaymentsByMonth = async (month: number) => {
 };
 
 const getCreditCardPaymentsByMonth = async () => {
-	const { data, error } = await supabase
-		.from(TABLE)
-		.select('*')
-		.eq('card_type', cardType['신용'])
-		.order('usage_date', { ascending: false });
+	const { data, error } = await supabase.from(TABLE).select('*').eq('card_type', cardType.CREDIT).order('usage_date', { ascending: false });
 
 	if (error) {
 		throw new Error(error.message);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -21,7 +21,7 @@ const calendar = months.reduce<Record<string, number[]>>((acc, _, idx) => {
 }, {});
 
 const formatByKoreanTime = (targetDate: Date | string): string => {
-	const _date = typeof targetDate === 'string' ? new Date(targetDate) : targetDate;
+	const _date = typeof targetDate === 'string' || typeof targetDate === 'object' ? new Date(targetDate) : targetDate;
 
 	const formattedDate = format(toZonedTime(_date, koreaTimeZone), 'yyyy/MM/dd', { timeZone: koreaTimeZone });
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -21,7 +21,7 @@ const calendar = months.reduce<Record<string, number[]>>((acc, _, idx) => {
 }, {});
 
 const formatByKoreanTime = (targetDate: Date | string): string => {
-	const _date = typeof targetDate === 'string' || typeof targetDate === 'object' ? new Date(targetDate) : targetDate;
+	const _date = typeof targetDate === 'string' || targetDate instanceof Date ? new Date(targetDate) : targetDate;
 
 	const formattedDate = format(toZonedTime(_date, koreaTimeZone), 'yyyy/MM/dd', { timeZone: koreaTimeZone });
 


### PR DESCRIPTION
### `FEAT`
- prevent from updating data to server on `TodoItem` inner-form in `TodoReminder` page
- make `targetDate` narrow using `instanceof` operator
  - `Date` type is regarded as `object` type in JavaScript
- show `EmptyMessage` UI when `fileteredData` has no length as well on `PaymentList` component in `ExpenseTrackerByMonth` page 
- make 3 constant to reuse (`ZERO_PRICE`, `WON_AND_JPY_SEPARATOR`, `USD_GBP_EUR_SEPARATOR`)
- sort `months.filter()` into 'descending' way in `CommuteRecords` page
- add `priceUnitType` state and use it to redefine data to be shown
- change `TODOS.PAGE_INFOE` of `staleTime`

### `REFACTOR`
- add blank line for code readability
- redefine `paymentMethod` as object literal and change all `cardType`'s keys
  - use object literal into `paymentData.paymentMethod`
  - change all `cardType`'s keys into English keyword
- use English keys for cardType in its implementation


### `FIX`
- resolve lexical scope issue with `modalType`
  - `ModalDataType` type uses `modalType` constant to determine the type of `modalType`'s value
  - The `modalType` constant needs to be hoisted because `typeof` is a JavaScript runtime operator
  