### PR TITLE
feat : add prevent auto-lock feature on IOS compulsorily

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,5 @@
 	<body>
 		<div id="root"></div>
 		<script type="module" src="/src/main.tsx"></script>
-		<script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=t5nuh6sau3"></script>
 	</body>
 </html>

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -22,7 +22,7 @@ const Select = <T extends string>({ data: options, placeholder, descriptionLabel
 	const targetRef = useClickOutside<HTMLDivElement>({ eventHandler: () => setOpen(false) });
 
 	return (
-		<SelectRoot ref={targetRef}>
+		<SelectRoot id="select-root" ref={targetRef}>
 			<SelectTrigger
 				type="button"
 				role="combobox"
@@ -41,7 +41,7 @@ const Select = <T extends string>({ data: options, placeholder, descriptionLabel
 			)}
 			<SelectContent isOpen={isOpen} aria-labelledby={`select-${generatedId}-content`}>
 				{descriptionLabel && <SelectDescriptionLabel>{descriptionLabel}</SelectDescriptionLabel>}
-				<SelectItemList>
+				<SelectItemList isLong={options.length > 6}>
 					{options.map((option, idx) => (
 						<SelectItem
 							key={`${option}_${idx}`}
@@ -131,11 +131,20 @@ const SelectDescriptionLabel = styled.span`
 	font-weight: var(--fw-medium);
 `;
 
-const SelectItemList = styled.div`
+const SelectItemList = styled.div<{ isLong: boolean }>`
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
 	width: 100%;
+	height: ${({ isLong }) => (isLong ? '300px' : 'auto')};
+	overflow-y: ${({ isLong }) => (isLong ? 'scroll' : 'auto')};
+
+	-webkit-overflow-scrolling: touch; // iOS scroll support
+	-ms-overflow-style: none; // IE and Edge
+	scrollbar-width: none; // Firefox
+	&::-webkit-scrollbar {
+		display: none; // hide scrollbar (optional)
+	}
 `;
 
 const SelectItem = styled.div<{ isCurrent: boolean }>`

--- a/src/components/expenseTracker/PaymentItemDetail.tsx
+++ b/src/components/expenseTracker/PaymentItemDetail.tsx
@@ -38,6 +38,7 @@ const Container = styled(ShrinkMotionBlock)`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	gap: 16px;
 	padding: var(--padding-container-mobile);
 	background-color: var(--greyOpacity50);
 	border: 1px solid var(--grey100);
@@ -55,6 +56,10 @@ const Container = styled(ShrinkMotionBlock)`
 		gap: 6px;
 		font-size: var(--fz-h7);
 		font-weight: var(--fw-semibold);
+
+		span {
+			text-align: right;
+		}
 	}
 `;
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { Outlet } from 'react-router-dom';
 import { Header, BottomNav, LayoutLoadingSpinner, QuickMemoDrawer, ModalContainer } from '..';
 import { useInitialScrollToTop } from '../../hooks';
+import { NavermapsProvider } from 'react-naver-maps';
 
 const layoutCss = {
 	wrapper: css`
@@ -40,15 +41,17 @@ const Layout = () => {
 
 	return (
 		<Suspense fallback={<LayoutLoadingSpinner />}>
-			<div id="layout-container" ref={layoutRef} css={layoutCss.wrapper}>
-				<Header />
-				<main id="layout-contents" css={layoutCss.main}>
-					<Outlet />
-				</main>
-				<BottomNav />
-				<QuickMemoDrawer />
-			</div>
-			<ModalContainer />
+			<NavermapsProvider ncpKeyId={import.meta.env.VITE_REACT_NAVER_MAPS_CLIENT_KEY}>
+				<div id="layout-container" ref={layoutRef} css={layoutCss.wrapper}>
+					<Header />
+					<main id="layout-contents" css={layoutCss.main}>
+						<Outlet />
+					</main>
+					<BottomNav />
+					<QuickMemoDrawer />
+				</div>
+				<ModalContainer />
+			</NavermapsProvider>
 		</Suspense>
 	);
 };

--- a/src/components/modal/commuteRecords/RecordModal.tsx
+++ b/src/components/modal/commuteRecords/RecordModal.tsx
@@ -62,6 +62,7 @@ const getDefaultValues = (action: CommuteRecordAction, data: ServiceDataType<Com
 
 const RecordModal = ({ id, type, action, data: serviceData, onClose }: RecordModalProps) => {
 	const { queryClient, session } = useClientSession();
+	const defaultValues = getDefaultValues(action, serviceData);
 
 	const {
 		register,
@@ -71,7 +72,7 @@ const RecordModal = ({ id, type, action, data: serviceData, onClose }: RecordMod
 		handleSubmit,
 	} = useForm<RecordSchema>({
 		resolver: zodResolver(recordSchema),
-		defaultValues: getDefaultValues(action, serviceData),
+		defaultValues,
 	});
 
 	const { startTransition, Loading, isLoading } = useLoading();
@@ -101,15 +102,22 @@ const RecordModal = ({ id, type, action, data: serviceData, onClose }: RecordMod
 							updated_at: date,
 					  });
 
+			if (action === 'EDIT') {
+				if (defaultValues?.notes === data.notes) {
+					addToast(toastData.COMMUTE_RECORDS.CUSTOM('warn', 'Notes are not changed'));
+					return;
+				}
+			}
+
 			await startTransition(callback);
 
-			onClose();
 			addToast(toastData.COMMUTE_RECORDS[actionProperty].SUCCESS);
 		} catch (e) {
 			console.error(e);
 			addToast(toastData.COMMUTE_RECORDS[actionProperty].ERROR);
 		} finally {
 			const _date = new Date(date);
+			onClose();
 
 			queryClient.invalidateQueries({
 				queryKey: [...queryKey.COMMUTE_RECORDS, `${_date.getFullYear()}-${(_date.getMonth() + 1 + '').padStart(2, '0')}`],

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -177,7 +177,11 @@ const toastData = {
 		},
 		EDIT: {
 			SUCCESS: { status: 'success', message: `Update commute ${FIXED_SUCCESS_PHRASE}` },
+
 			ERROR: { status: 'error', message: `${FIXED_ERROR_MESSAGE_PHRASE} updating ` },
+		},
+		CUSTOM(status: Toast['status'], message: string) {
+			return { status, message };
 		},
 	},
 	FAVORITE_PLACE: {


### PR DESCRIPTION
### feat 
- add prevent auto-lock feature on IOS Safari 17.4+ compulsorily, using **Wake Lock API**
  - should check if it works on older IOS versions(< 17.4+)

### fix
- use `NavermapsProvider` to hide `ncpClientId` using naver-maps api
- prevent `Edit` action if previous and updated `notes` are same on `CommuteRecords` page


### style
- add scroll-y behavior if `Select`'s options are too long using style props of Emotion.js
- fix non-gap UI on `PaymentItemDetail` component
