### PR TITLE
feat : develop `suspendImage` to show image with Suspense UI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
   - Credit Card Transaction List
   - Upcoming Credit Card Transaction
 - TodoReminder : Write todos which are to be checked in need
-- Commute Tracker (WIP)
+- Commute Tracker : Keep track of commuting records
+- PomodoroTimer : Helps us stand up consistently from our seat, supporting our back and neck health
+- Favorite Place(WIP) : Add personal favorite place on Map
 
 ## Tech Stacks
 

--- a/src/components/common/LazyImage.tsx
+++ b/src/components/common/LazyImage.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import { useIsImageLoaded } from '../../hooks';
 import placeholderImage from '../../assets/placeholder-gray.webp';
+import { suspendImage } from '../../utils';
 
 interface LazyImageProps {
 	src: string;
@@ -11,13 +11,15 @@ interface LazyImageProps {
 }
 
 const LazyImage = ({ src, alt, width, height, lazy = true }: LazyImageProps) => {
-	const { elementRef, isLoaded } = useIsImageLoaded(lazy);
+	if (lazy && src) {
+		suspendImage(src);
+	}
 
 	return (
 		<Container>
 			<img
-				ref={elementRef}
-				src={isLoaded ? src : placeholderImage}
+				// ref={elementRef}
+				src={src || placeholderImage}
 				alt={alt}
 				style={{ display: 'block', width, height }}
 				sizes="(max-width: 640px) 300px, 380px"

--- a/src/components/filmRecipe/index.ts
+++ b/src/components/filmRecipe/index.ts
@@ -1,3 +1,5 @@
+export * from './loader';
+
 export { default as FilmRecipeContentLoader } from './FilmRecipeContentLoader';
 export { default as FilmRecipeContent } from './FilmRecipeContent';
 export { default as FilmRecipeImageUpload } from './FilmRecipeImageUpload';

--- a/src/components/filmRecipe/loader/LazyImageLoader.tsx
+++ b/src/components/filmRecipe/loader/LazyImageLoader.tsx
@@ -1,0 +1,7 @@
+import { SkeletonLoader } from '../../common';
+
+const LazyImageLoader = () => {
+	return <SkeletonLoader width={'100%'} height={'300px'} />;
+};
+
+export default LazyImageLoader;

--- a/src/components/filmRecipe/loader/index.ts
+++ b/src/components/filmRecipe/loader/index.ts
@@ -1,0 +1,1 @@
+export { default as LazyImageLoader } from './LazyImageLoader';

--- a/src/components/layout/NavLink.tsx
+++ b/src/components/layout/NavLink.tsx
@@ -10,7 +10,6 @@ interface NavLinkProps {
 
 const NavLink = ({ href, children }: NavLinkProps) => {
 	const { pathname } = useLocation();
-	console.log(pathname, href);
 
 	return (
 		<StyledLink to={href} $isCurrentUrl={pathname === href || (href !== routes.HOME && pathname.includes(href))}>

--- a/src/components/modal/filmRecipe/FilmRecipeModal.tsx
+++ b/src/components/modal/filmRecipe/FilmRecipeModal.tsx
@@ -1,10 +1,19 @@
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import styled from '@emotion/styled';
 import placeholderImage from '../../../assets/placeholder-gray.webp';
 import { FaStar } from 'react-icons/fa';
 import { FaRegStar } from 'react-icons/fa6';
 import { MODAL_CONFIG, type ModalDataType } from '..';
-import { ModalLayout, LazyImage, FilmRecipeImageUpload, TextInput, CustomSelect, Button, FilmRecipeStaticFields } from '../..';
+import {
+	ModalLayout,
+	LazyImage,
+	FilmRecipeImageUpload,
+	TextInput,
+	CustomSelect,
+	Button,
+	FilmRecipeStaticFields,
+	LazyImageLoader,
+} from '../..';
 import { editRecipe, type RestricedRecipeWithImage } from '../../../supabase';
 import { useModalStore, useToastStore } from '../../../store';
 import { useClientSession, useFilmRecipeImage, useLoading } from '../../../hooks';
@@ -108,17 +117,19 @@ const FilmRecipeModal = ({ id, type, data, onClose }: FilmRecipeModalProps) => {
 						setImageUrlOnEditing={setImageUrlOnEditing}
 					/>
 				) : (
-					<LazyImage
-						src={
-							data?.imgSrc?.includes(`${import.meta.env.VITE_SUPABASE_PROJECT_URL}/${import.meta.env.VITE_SUPABASE_FILMRECIPE_URL}`)
-								? data?.imgSrc
-								: placeholderImage
-						}
-						alt="recipe sample image"
-						width={'100%'}
-						height={'100%'}
-						lazy={true}
-					/>
+					<Suspense fallback={<LazyImageLoader />}>
+						<LazyImage
+							src={
+								data?.imgSrc?.includes(`${import.meta.env.VITE_SUPABASE_PROJECT_URL}/${import.meta.env.VITE_SUPABASE_FILMRECIPE_URL}`)
+									? data?.imgSrc
+									: placeholderImage
+							}
+							alt="recipe sample image"
+							width={'100%'}
+							height={'100%'}
+							lazy={true}
+						/>
+					</Suspense>
 				)}
 
 				{isEditing ? (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './validateField';
 export * from './expenseTracker';
 
 export { default as mergeRefs } from './mergeRefs';
+export { default as suspendImage } from './suspendImage';

--- a/src/utils/suspendImage.ts
+++ b/src/utils/suspendImage.ts
@@ -1,0 +1,28 @@
+const imageCache = new Map<string, Promise<void>>();
+const loadedImages = new Set<string>();
+
+const loadImage = (src: string) => {
+	return new Promise<void>((resolve, reject) => {
+		const image = new window.Image();
+		image.src = src;
+		image.onload = () => {
+			loadedImages.add(src);
+			resolve();
+		};
+		image.onerror = reject;
+	});
+};
+
+const suspendImage = (src: string) => {
+	if (loadedImages.has(src)) {
+		return;
+	}
+
+	if (!imageCache.has(src)) {
+		imageCache.set(src, loadImage(src));
+	}
+
+	throw imageCache.get(src);
+};
+
+export default suspendImage;


### PR DESCRIPTION
### feat

- develop `suspendImage` to show image with Suspense UI
  - In most of services, `useIsElementInViewport` hook is useful to show list or gallery of images
  - In this case, specific image is necessarily loaded fully on `Modal` component
  - using `Map` and `Set` with Promise for caching strategy

### docs
- update readme